### PR TITLE
fix(frontend): break shared references to DefaultState metadata

### DIFF
--- a/labextension/src/__tests__/leftPanelTypes.spec.ts
+++ b/labextension/src/__tests__/leftPanelTypes.spec.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 The Kubeflow Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createDefaultMetadata, DefaultState } from '../widgets/LeftPanelTypes';
+
+// Regression tests for https://github.com/kubeflow/kale/issues/643:
+// notebook state must never share object references with the DefaultState
+// global, otherwise an in-place write leaks into every open notebook.
+describe('createDefaultMetadata', () => {
+  it('returns a fresh metadata object on every call', () => {
+    const first = createDefaultMetadata();
+    const second = createDefaultMetadata();
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+  });
+
+  it('returns fresh nested objects and arrays on every call', () => {
+    const first = createDefaultMetadata();
+    const second = createDefaultMetadata();
+    expect(first.experiment).not.toBe(second.experiment);
+    expect(first.steps_defaults).not.toBe(second.steps_defaults);
+  });
+
+  it('does not share references with DefaultState.metadata', () => {
+    const metadata = createDefaultMetadata();
+    expect(metadata).not.toBe(DefaultState.metadata);
+    expect(metadata.experiment).not.toBe(DefaultState.metadata.experiment);
+    expect(metadata.steps_defaults).not.toBe(
+      DefaultState.metadata.steps_defaults,
+    );
+  });
+
+  it('produces objects that are safe to mutate without affecting defaults', () => {
+    const metadata = createDefaultMetadata();
+    metadata.pipeline_description = 'mutated';
+    metadata.steps_defaults!.push('label:mutated');
+    const fresh = createDefaultMetadata();
+    expect(fresh.pipeline_description).toBe('');
+    expect(fresh.steps_defaults).toEqual([]);
+  });
+});
+
+describe('DefaultState', () => {
+  it('is deep-frozen so in-place writes cannot leak between notebooks', () => {
+    expect(Object.isFrozen(DefaultState)).toBe(true);
+    expect(Object.isFrozen(DefaultState.metadata)).toBe(true);
+    expect(Object.isFrozen(DefaultState.metadata.experiment)).toBe(true);
+    expect(Object.isFrozen(DefaultState.metadata.steps_defaults)).toBe(true);
+  });
+
+  it('keeps the documented default values', () => {
+    expect(DefaultState.metadata).toEqual(createDefaultMetadata());
+  });
+});

--- a/labextension/src/widgets/LeftPanelTypes.ts
+++ b/labextension/src/widgets/LeftPanelTypes.ts
@@ -56,14 +56,27 @@ export interface IKaleNotebookMetadata {
   output_path?: string;
 }
 
-export const DefaultState = {
-  metadata: {
+// Every consumer must get its own copy: sharing one mutable object between
+// the React state of different notebooks leaks values across them (#643).
+export function createDefaultMetadata(): IKaleNotebookMetadata {
+  return {
     experiment: { id: '', name: '' },
     experiment_name: '',
     pipeline_name: '',
     pipeline_description: '',
     base_image: '',
     enable_caching: true,
-    steps_defaults: [] as string[],
-  } as IKaleNotebookMetadata,
-};
+    steps_defaults: [],
+  };
+}
+
+const frozenMetadata = createDefaultMetadata();
+Object.freeze(frozenMetadata.experiment);
+Object.freeze(frozenMetadata.steps_defaults);
+Object.freeze(frozenMetadata);
+
+// Frozen so an accidental in-place write throws instead of silently
+// leaking into every open notebook.
+export const DefaultState = Object.freeze({
+  metadata: frozenMetadata,
+});

--- a/labextension/src/widgets/hooks/useDeployment.ts
+++ b/labextension/src/widgets/hooks/useDeployment.ts
@@ -19,7 +19,7 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import { PageConfig } from '@jupyterlab/coreutils';
 import { DeployProgressState } from '../deploys-progress/DeployProgress';
 import {
-  DefaultState,
+  createDefaultMetadata,
   DeployType,
   IKaleNotebookMetadata,
 } from '../LeftPanelTypes';
@@ -69,7 +69,7 @@ export function useDeployment({
   const runDeploymentRef = useRef(false);
   runDeploymentRef.current = runDeployment;
 
-  const metadataRef = useRef<IKaleNotebookMetadata>(DefaultState.metadata);
+  const metadataRef = useRef<IKaleNotebookMetadata>(createDefaultMetadata());
   const namespaceRef = useRef('');
   const deployDebugMessageRef = useRef(false);
   const deploymentTypeRef = useRef<DeployType>('compile');

--- a/labextension/src/widgets/hooks/useNotebookLoader.ts
+++ b/labextension/src/widgets/hooks/useNotebookLoader.ts
@@ -18,7 +18,11 @@ import { Kernel } from '@jupyterlab/services';
 import { PageConfig } from '@jupyterlab/coreutils';
 import NotebookUtils from '../../lib/NotebookUtils';
 import Commands from '../../lib/Commands';
-import { DefaultState, IExperiment, NEW_EXPERIMENT } from '../LeftPanelTypes';
+import {
+  createDefaultMetadata,
+  IExperiment,
+  NEW_EXPERIMENT,
+} from '../LeftPanelTypes';
 import { ILoaderSetters } from './useNotebookMetadata';
 import DeployUtils from '../deploys-progress/DeployUtils';
 
@@ -202,17 +206,16 @@ export function useNotebookLoader({
               : sanitized,
           pipeline_description: notebookMetadata['pipeline_description'] || '',
           base_image: '',
-          steps_defaults: DefaultState.metadata.steps_defaults,
+          steps_defaults: createDefaultMetadata().steps_defaults,
         });
       } else {
         const defaultPipelineName = getNotebookFileName(notebook);
         const sanitized = sanitizePipelineName(defaultPipelineName);
         setMetadata(prev => ({
-          ...DefaultState.metadata,
+          ...createDefaultMetadata(),
           experiment: prev.experiment,
           experiment_name: prev.experiment_name,
           pipeline_name: sanitized,
-          base_image: DefaultState.metadata.base_image,
         }));
       }
     },

--- a/labextension/src/widgets/hooks/useNotebookMetadata.ts
+++ b/labextension/src/widgets/hooks/useNotebookMetadata.ts
@@ -23,7 +23,7 @@ import {
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { Kernel } from '@jupyterlab/services';
 import {
-  DefaultState,
+  createDefaultMetadata,
   IDeployPanelCustomLinks,
   IExperiment,
   IKaleNotebookMetadata,
@@ -33,7 +33,6 @@ import { useNotebookMetadataPersistence } from './useNotebookMetadataPersistence
 import { useEnableByDefaultEffect } from './useEnableByDefaultEffect';
 
 const KALE_NOTEBOOK_METADATA_KEY = 'kubeflow_notebook';
-const defaultMetadata = DefaultState.metadata;
 
 export interface INotebookMetadataState {
   metadata: IKaleNotebookMetadata;
@@ -82,8 +81,9 @@ export function useNotebookMetadata({
   kernel,
   enableKaleByDefault,
 }: IUseNotebookMetadataParams): INotebookMetadataState {
-  const [metadata, setMetadata] =
-    useState<IKaleNotebookMetadata>(defaultMetadata);
+  const [metadata, setMetadata] = useState<IKaleNotebookMetadata>(
+    createDefaultMetadata,
+  );
   const [experiments, setExperiments] = useState<IExperiment[]>([]);
   const [gettingExperiments, setGettingExperiments] = useState(false);
   const [isEnabled, setIsEnabled] = useState(false);
@@ -123,7 +123,7 @@ export function useNotebookMetadata({
   }, []);
 
   const resetForNoNotebook = useCallback(() => {
-    setMetadata(defaultMetadata);
+    setMetadata(createDefaultMetadata());
     setExperiments([]);
     setGettingExperiments(false);
     setIsEnabled(false);


### PR DESCRIPTION
Fixes #643

The direct mutation from the original report was removed in #754, but the shared references remained: the left panel state was initialized with the same object as `DefaultState.metadata`, and its `steps_defaults` array was shared into every notebook's state. Any in-place write would still leak across notebooks and get persisted into their .ipynb files.

- add `createDefaultMetadata()` so every consumer gets a fresh copy
- freeze `DefaultState` so an accidental in-place write throws instead of silently leaking
- add regression tests