### PR TITLE
fix(backend): handle async functions in AST parsing utilities

### DIFF
--- a/kale/common/astutils.py
+++ b/kale/common/astutils.py
@@ -128,6 +128,7 @@ def get_marshal_candidates(code):
     #  Context manager (just the alias)
     contexts = (
         ast.FunctionDef,
+        ast.AsyncFunctionDef,
         ast.ClassDef,
     )
     tree = ast.parse(commented_code)
@@ -154,10 +155,10 @@ def get_marshal_candidates(code):
 def parse_functions(code):
     """Parse all the global functions present in the input code.
 
-    Parse all the ast nodes ast.FunctionDef that are global functions in the
-    source code. These also include function that are defined inside other
-    Python statements, like `try`. ast.ClassDef nodes are skipped from the
-    parsing so that class functions are ignored.
+    Parse all the ast.FunctionDef and ast.AsyncFunctionDef nodes that are
+    global functions in the source code. These also include functions that are
+    defined inside other Python statements, like `try`. ast.ClassDef nodes are
+    skipped from the parsing so that class functions are ignored.
 
     Args:
         code (str): Multiline string representing Python code
@@ -167,8 +168,12 @@ def parse_functions(code):
     fns = {}
     tree = ast.parse(code)
     for block in tree.body:
-        for node in walk(block, stop_at=(ast.FunctionDef,), ignore=(ast.ClassDef,)):
-            if isinstance(node, ast.FunctionDef):
+        for node in walk(
+            block,
+            stop_at=(ast.FunctionDef, ast.AsyncFunctionDef),
+            ignore=(ast.ClassDef,),
+        ):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 fn_name = node.name
                 fns[fn_name] = astor.to_source(node)
     return fns
@@ -227,7 +232,7 @@ def get_function_and_class_names(code):
         for node in walk(block):
             if isinstance(
                 node,
-                ast.FunctionDef | ast.ClassDef,
+                ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
             ):
                 names.add(node.name)
     return names

--- a/kale/tests/unit_tests/test_ast.py
+++ b/kale/tests/unit_tests/test_ast.py
@@ -51,6 +51,14 @@ class test:
         self.a = b
 """
 
+_async_snippet = """
+async def _test(a):
+    local_var = a
+
+async def _test2(b, *args, **kwargs):
+    var = b
+"""
+
 _ctx_mngr_snippet = """
 with my_context(param) as ctx:
     res = ctx.use()
@@ -71,6 +79,9 @@ def fun()
         (_foos_snippet, ["_test", "_test2"]),
         (_class_snippet, ["test"]),
         (_ctx_mngr_snippet, ["my_context", "param", "res", "ctx"]),
+        # async functions are treated like regular functions: the function
+        # name is a candidate, their local variables must not leak out.
+        (_async_snippet, ["_test", "_test2"]),
     ],
 )
 def test_get_marshal_candidates(code, target):
@@ -105,7 +116,12 @@ def test_get_list_tuple_names(code, target):
 
 @pytest.mark.parametrize(
     "code,target",
-    [("", []), (_foos_snippet, ["_test", "_test2"]), (_class_snippet, ["__init__", "foo", "test"])],
+    [
+        ("", []),
+        (_foos_snippet, ["_test", "_test2"]),
+        (_class_snippet, ["__init__", "foo", "test"]),
+        (_async_snippet, ["_test", "_test2"]),
+    ],
 )
 def test_get_function_and_class_names(code, target):
     """Test get_function_and_class_names function."""
@@ -180,6 +196,19 @@ def foo():
     """
 
     target = {"foo": "def foo():\n    print('hello')\n    print(x)\n"}
+    assert kale_ast.parse_functions(code) == target
+
+
+def test_parse_functions_async():
+    """async functions must be parsed just like regular functions."""
+    code = """
+x = 5
+async def foo():
+    print('hello')
+    print(x)
+    """
+
+    target = {"foo": "async def foo():\n    print('hello')\n    print(x)\n"}
     assert kale_ast.parse_functions(code) == target
 
 


### PR DESCRIPTION
## What this does

Treats `ast.AsyncFunctionDef` the same as `ast.FunctionDef` in `kale/common/astutils.py`, so `async def` helpers in a `functions`/`step` cell are handled correctly by:

- `parse_functions` — now extracts async functions (previously dropped them).
- `get_function_and_class_names` — now registers async function names.
- `get_marshal_candidates` — now stops at async function bodies, so it no longer leaks their local variables and correctly adds the function name.

## Why

`astutils` only checked `ast.FunctionDef`, so an `async def` was mishandled in three ways. Reproducer on `main`:

```python
from kale.common import astutils

astutils.parse_functions("async def foo():\n    return 1")
# {}                      -> expected {"foo": ...}

astutils.get_function_and_class_names("async def foo():\n    pass")
# set()                   -> expected {"foo"}

astutils.get_marshal_candidates("async def foo():\n    local_x = 1\n    return local_x")
# ['local_x']             -> expected ['foo']
```

The `get_marshal_candidates` case is the most harmful: it walked into the async function body and returned the function's **local** variable as a marshal candidate while missing the function name. In a pipeline this means an `async def` helper would not be injected into steps, would be treated as a missing dependency, and its internals could be marshalled between steps.

## Testing

Extended `kale/tests/unit_tests/test_ast.py` with an async snippet and a dedicated `parse_functions` async test. All three new assertions fail on `main` and pass with this change; the full `test_ast.py` suite (47 tests) passes.

I came across this while working on the output-artifact/AST code in #874. Happy to open a tracking issue if maintainers prefer.
