### PR TITLE
fix(backend): show a friendly error when KFP is unreachable

### DIFF
--- a/kale/rpc/kfp.py
+++ b/kale/rpc/kfp.py
@@ -12,15 +12,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import os
 
+import requests.exceptions
+import urllib3.exceptions
+
 from kale.common import kfp_client_factory, kfputils
+from kale.rpc.errors import RPCServiceUnavailableError
+from kale.rpc.log import KALE_LOG_FILE
 
 log = logging.getLogger(__name__)
 
 KALE_UPLOAD_LINK_ENV = "KALE_UPLOAD_LINK"
 KALE_RUN_LINK_ENV = "KALE_RUN_LINK"
+
+# Errors raised by the KFP client (directly, or via urllib3/requests under
+# the hood) when the KFP API server cannot be reached at all, e.g. because
+# the configured host is wrong or the server is down.
+_KFP_CONNECTION_ERRORS = (
+    urllib3.exceptions.MaxRetryError,
+    requests.exceptions.ConnectionError,
+)
+
+
+def _handle_unreachable_kfp(func):
+    """Turn KFP connection failures into a friendly, actionable RPC error."""
+
+    @functools.wraps(func)
+    def wrapper(request, *args, **kwargs):
+        try:
+            return func(request, *args, **kwargs)
+        except _KFP_CONNECTION_ERRORS:
+            request.log.exception(
+                "RPC function '%s' failed because KFP is not reachable", func.__name__
+            )
+            raise RPCServiceUnavailableError(
+                message="KFP is not reachable.",
+                # The frontend prefers showing `details` over `message` alone,
+                # so repeat the headline here to keep the dialog self-contained.
+                details=(
+                    "KFP is not reachable. You can still compile notebooks, "
+                    "but you cannot upload or run pipelines. You can find "
+                    f"more information under {KALE_LOG_FILE}"
+                ),
+                trans_id=request.trans_id,
+            )
+
+    return wrapper
 
 
 def _get_client(host=None):
@@ -37,6 +77,7 @@ def ping(request):
         return False
 
 
+@_handle_unreachable_kfp
 def list_experiments(request):
     """List Kubeflow Pipelines experiments."""
     c = _get_client()
@@ -47,6 +88,7 @@ def list_experiments(request):
     return experiments
 
 
+@_handle_unreachable_kfp
 def get_ui_host(request):
     """Get a UI Host. If it does not exist return None."""
     c = _get_client()
@@ -85,6 +127,7 @@ def get_custom_links(request):
     }
 
 
+@_handle_unreachable_kfp
 def get_experiment(request, experiment_name):
     """Get a KFP experiment. If it does not exist return None."""
     client = _get_client()
@@ -107,10 +150,11 @@ def get_experiment(request, experiment_name):
     return {"id": experiment.experiment_id, "name": experiment.display_name}
 
 
+@_handle_unreachable_kfp
 def create_experiment(request, experiment_name, raise_if_exists=False):
     """Create a new experiment."""
     client = _get_client()
-    exp = get_experiment(None, experiment_name)
+    exp = get_experiment(request, experiment_name)
     if not exp:
         experiment = client.create_experiment(name=experiment_name)
         return {"id": experiment.experiment_id, "name": experiment.display_name}
@@ -118,6 +162,7 @@ def create_experiment(request, experiment_name, raise_if_exists=False):
         raise ValueError("Failed to create experiment, experiment already exists.")
 
 
+@_handle_unreachable_kfp
 def upload_pipeline(request, pipeline_package_path, pipeline_metadata):
     """Upload a KFP package as a new pipeline."""
     pipeline_name = pipeline_metadata["pipeline_name"]
@@ -125,6 +170,7 @@ def upload_pipeline(request, pipeline_package_path, pipeline_metadata):
     return {"pipeline": {"pipelineid": pid, "versionid": vid, "name": pipeline_name}}
 
 
+@_handle_unreachable_kfp
 def run_pipeline(request, pipeline_metadata, pipeline_id, version_id, pipeline_package_path):
     """Run a pipeline."""
     run = kfputils.run_pipeline(
@@ -137,6 +183,7 @@ def run_pipeline(request, pipeline_metadata, pipeline_id, version_id, pipeline_p
     return {"id": run.run_id, "name": run.run_info.display_name, "status": run.run_info.state}
 
 
+@_handle_unreachable_kfp
 def get_run(request, run_id):
     """Get an existing run's details."""
     client = _get_client()

--- a/kale/rpc/kfp.py
+++ b/kale/rpc/kfp.py
@@ -69,6 +69,9 @@ def _get_client(host=None):
 
 
 def ping(request):
+    # Intentionally not decorated with `_handle_unreachable_kfp`: this is the
+    # reachability probe itself, and it already reports an unreachable server
+    # by returning False rather than by raising.
     try:
         c = _get_client()
         c.get_kfp_healthz()

--- a/kale/tests/unit_tests/test_rpc_kfp.py
+++ b/kale/tests/unit_tests/test_rpc_kfp.py
@@ -62,6 +62,22 @@ def test_list_experiments_kfp_unreachable(_rpc_request, connection_error):
     assert err.trans_id == _rpc_request.trans_id
 
 
+def test_list_experiments_kfp_unreachable_on_api_call(_rpc_request):
+    """The common case: the client builds fine and the API call is what fails.
+
+    `kfp.Client.__init__` only contacts the server when no namespace is set, and
+    Kale normally has one, so `_get_client()` succeeds and the connection error
+    surfaces from the API call inside the decorated function body.
+    """
+    client = mock.MagicMock()
+    client.list_experiments.side_effect = _max_retry_error()
+    with (
+        mock.patch("kale.rpc.kfp._get_client", return_value=client),
+        pytest.raises(RPCServiceUnavailableError),
+    ):
+        kfp.list_experiments(_rpc_request)
+
+
 def test_get_run_kfp_unreachable(_rpc_request):
     with (
         mock.patch("kale.rpc.kfp._get_client", side_effect=_max_retry_error()),
@@ -70,10 +86,43 @@ def test_get_run_kfp_unreachable(_rpc_request):
         kfp.get_run(_rpc_request, "run-id")
 
 
-def test_create_experiment_kfp_unreachable(_rpc_request):
-    """Connection errors raised while checking for an existing experiment propagate."""
+def test_get_run_kfp_unreachable_on_api_call(_rpc_request):
+    client = mock.MagicMock()
+    client.get_run.side_effect = _max_retry_error()
     with (
-        mock.patch("kale.rpc.kfp._get_client", side_effect=_max_retry_error()),
+        mock.patch("kale.rpc.kfp._get_client", return_value=client),
+        pytest.raises(RPCServiceUnavailableError),
+    ):
+        kfp.get_run(_rpc_request, "run-id")
+
+
+def test_create_experiment_kfp_unreachable(_rpc_request):
+    """Connection errors raised while checking for an existing experiment propagate.
+
+    The first `_get_client()` succeeds so that execution actually reaches the
+    nested `get_experiment(request, ...)` call, which is where the failure is
+    raised. This pins the `request` (not `None`) argument to that nested call:
+    `get_experiment` is decorated, so passing `None` would dereference
+    `None.log` and turn the connection error into an `AttributeError`.
+    """
+    outer_client = mock.MagicMock()
+    with (
+        mock.patch(
+            "kale.rpc.kfp._get_client",
+            side_effect=[outer_client, _max_retry_error()],
+        ),
+        pytest.raises(RPCServiceUnavailableError),
+    ):
+        kfp.create_experiment(_rpc_request, "my-experiment")
+
+
+def test_create_experiment_kfp_unreachable_on_api_call(_rpc_request):
+    """The existence check succeeds, then creating the experiment hits the network."""
+    client = mock.MagicMock()
+    client.get_experiment.side_effect = ValueError("No experiment is found with name my-experiment")
+    client.create_experiment.side_effect = _max_retry_error()
+    with (
+        mock.patch("kale.rpc.kfp._get_client", return_value=client),
         pytest.raises(RPCServiceUnavailableError),
     ):
         kfp.create_experiment(_rpc_request, "my-experiment")

--- a/kale/tests/unit_tests/test_rpc_kfp.py
+++ b/kale/tests/unit_tests/test_rpc_kfp.py
@@ -1,0 +1,88 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+import requests.exceptions
+import urllib3.exceptions
+
+from kale.rpc import kfp
+from kale.rpc.errors import RPCServiceUnavailableError
+from kale.rpc.log import KALE_LOG_FILE
+from kale.rpc.run import KaleRPCRequest
+
+
+@pytest.fixture
+def _rpc_request():
+    return KaleRPCRequest()
+
+
+def _max_retry_error():
+    pool = urllib3.connectionpool.HTTPConnectionPool(host="localhost", port=55555)
+    return urllib3.exceptions.MaxRetryError(
+        pool,
+        "/apis/v2beta1/experiments",
+        reason=Exception("Failed to establish a new connection: [Errno 111] Connection refused"),
+    )
+
+
+@pytest.mark.parametrize(
+    "connection_error",
+    [
+        _max_retry_error(),
+        requests.exceptions.ConnectionError("Connection refused"),
+    ],
+)
+def test_list_experiments_kfp_unreachable(_rpc_request, connection_error):
+    """A KFP connection failure should surface as a friendly, actionable error."""
+    with (
+        mock.patch("kale.rpc.kfp._get_client", side_effect=connection_error),
+        pytest.raises(RPCServiceUnavailableError) as exc_info,
+    ):
+        kfp.list_experiments(_rpc_request)
+
+    err = exc_info.value
+    assert err.message == "KFP is not reachable."
+    assert "KFP is not reachable" in err.details
+    assert "compile notebooks" in err.details
+    assert "upload or run pipelines" in err.details
+    assert KALE_LOG_FILE in err.details
+    assert err.trans_id == _rpc_request.trans_id
+
+
+def test_get_run_kfp_unreachable(_rpc_request):
+    with (
+        mock.patch("kale.rpc.kfp._get_client", side_effect=_max_retry_error()),
+        pytest.raises(RPCServiceUnavailableError),
+    ):
+        kfp.get_run(_rpc_request, "run-id")
+
+
+def test_create_experiment_kfp_unreachable(_rpc_request):
+    """Connection errors raised while checking for an existing experiment propagate."""
+    with (
+        mock.patch("kale.rpc.kfp._get_client", side_effect=_max_retry_error()),
+        pytest.raises(RPCServiceUnavailableError),
+    ):
+        kfp.create_experiment(_rpc_request, "my-experiment")
+
+
+def test_list_experiments_unrelated_error_not_swallowed(_rpc_request):
+    """Non-connection errors should not be turned into a service-unavailable error."""
+    with (
+        mock.patch("kale.rpc.kfp._get_client", side_effect=ValueError("boom")),
+        pytest.raises(ValueError),
+    ):
+        kfp.list_experiments(_rpc_request)


### PR DESCRIPTION
## Summary
- When the KFP API server is unreachable (wrong host, server down, connection refused, etc.), the RPC layer used to let the raw `urllib3.exceptions.MaxRetryError` / `requests.exceptions.ConnectionError` bubble up, which the frontend displayed as an unhelpful generic error dialog.
- `kale/rpc/kfp.py` now catches those connection errors on every KFP-touching RPC entry point (`list_experiments`, `get_ui_host`, `get_experiment`, `create_experiment`, `upload_pipeline`, `run_pipeline`, `get_run`) and raises the existing (previously unused) `RPCServiceUnavailableError`, so the user instead sees:
  > KFP is not reachable. You can still compile notebooks, but you cannot upload or run pipelines. You can find more information under `<HOME>/kale.log`
- No frontend changes were needed — `_legacy_executeRpcAndShowRPCError` in `labextension/src/lib/RPCUtils.tsx` already prefers `err_details` when showing the dialog.

Fixes #883

## Test plan
- [x] Added `kale/tests/unit_tests/test_rpc_kfp.py` covering `MaxRetryError`/`ConnectionError` handling on `list_experiments`, `get_run`, `create_experiment`, and confirming unrelated errors (e.g. `ValueError`) are not swallowed.
- [x] `uv run pytest kale/tests -vv` — 254 backend tests pass (2 pre-existing/unrelated `e2e` failures reproduce identically on `main`, confirmed before this change).
- [x] `uv run ruff check kale` and `uv run ruff format --check kale` pass.