### PR TITLE
chore(backend): move nbprocessor constants into a separate module

### DIFF
--- a/kale/processors/constants.py
+++ b/kale/processors/constants.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Constants used when processing a notebook into a pipeline.
+
+Grouped by what each string actually *is*, since they are not
+interchangeable: keys read from the notebook JSON, the cell tag language,
+the keys of the parsed-tag dictionary shared between
+``parse_cell_metadata`` and ``parse_notebook``, names of
+:class:`~kale.step.Step` attributes looked up dynamically, and code
+templates / type maps.
+"""
+
+# --------------------------------------------------------------------------
+# Notebook JSON keys and the cell tag language
+# --------------------------------------------------------------------------
+
+# fixme: Change the name of this key to `kale_metadata`
+KALE_NB_METADATA_KEY = "kubeflow_notebook"
+
+SKIP_TAG = r"^skip$"
+IMPORT_TAG = r"^imports$"
+FUNCTIONS_TAG = r"^functions$"
+PREV_TAG = r"^prev:[_a-z]([_a-z0-9]*)?$"
+STEP_TAG = r"^step:([_a-z]([_a-z0-9]*)?)?$"
+# A `notebook:<name>` cell references another notebook as a sub-pipeline. The
+# referenced path is carried in the cell metadata (`notebook_path`), not the tag.
+NOTEBOOK_TAG = r"^notebook:([_a-z]([_a-z0-9]*)?)?$"
+PIPELINE_PARAMETERS_TAG = r"^pipeline-parameters$"
+PIPELINE_METRICS_TAG = r"^pipeline-metrics$"
+# Annotations map to actual pod annotations that can be set via KFP SDK
+_segment = "[a-zA-Z0-9]+([a-zA-Z0-9-_.]*[a-zA-Z0-9])?"
+K8S_ANNOTATION_KEY = f"{_segment}([/]{_segment})?"
+ANNOTATION_TAG = rf"^annotation:{K8S_ANNOTATION_KEY}:(.*)$"
+LABEL_TAG = rf"^label:{K8S_ANNOTATION_KEY}:(.*)$"
+# Limits map to K8s limits, like CPU, Mem, GPU, ...
+# E.g.: limit:nvidia.com/gpu:2
+LIMITS_TAG = r"^limit:([_a-z-\.\/]+):([_a-zA-Z0-9\.]+)$"
+# Image tag for per-step Base image selection
+# E.g.: image:python:3.11-slim
+IMAGE_TAG = r"^image:(.+)$"
+# Cache tag for per-step caching control
+# E.g.: cache:enabled or cache:disabled
+CACHE_ENABLED = "enabled"
+CACHE_DISABLED = "disabled"
+CACHE_TAG = rf"^cache:({CACHE_ENABLED}|{CACHE_DISABLED})$"
+# Report tag for per-step HTML report generation control
+# E.g.: report:enabled or report:disabled
+REPORT_ENABLED = "enabled"
+REPORT_DISABLED = "disabled"
+REPORT_TAG = rf"^report:({REPORT_ENABLED}|{REPORT_DISABLED})$"
+
+TAGS_LANGUAGE = [
+    SKIP_TAG,
+    IMPORT_TAG,
+    FUNCTIONS_TAG,
+    PREV_TAG,
+    STEP_TAG,
+    NOTEBOOK_TAG,
+    PIPELINE_PARAMETERS_TAG,
+    PIPELINE_METRICS_TAG,
+    ANNOTATION_TAG,
+    LABEL_TAG,
+    LIMITS_TAG,
+    IMAGE_TAG,
+    CACHE_TAG,
+    REPORT_TAG,
+]
+# These tags are applied to every step of the pipeline
+STEPS_DEFAULTS_LANGUAGE = [ANNOTATION_TAG, LABEL_TAG, LIMITS_TAG, IMAGE_TAG, CACHE_TAG, REPORT_TAG]
+
+
+METRICS_TEMPLATE = """\
+from kale.common import kfputils as _kale_kfputils
+_kale_kfp_metrics = {
+%s
+}
+_kale_kfputils.generate_mlpipeline_metrics(_kale_kfp_metrics)\
+"""
+
+KFP_ARTIFACT_TYPE_MAP = {
+    "model": "Model",  # if "model" in var_name.lower()-> kfp.dsl.Model
+    "dataset": "Dataset",  # if "dataset" in var_name.lower()-> kfp.dsl.Dataset
+    "data": "Dataset",  # if "data" in var_name.lower()-> kfp.dsl.Dataset
+    "metrics": "Metrics",  # if "metrics" in var_name.lower()-> kfp.dsl.Metrics
+    "classification": "ClassificationMetrics",
+    r"a-zA-Z0-9_": "Artifact",  # default for any other variable
+}
+
+
+# Separator between a tag's parts, e.g. `limit:nvidia.com/gpu:2`.
+TAG_SEPARATOR = ":"
+
+# Cell-level metadata key holding the list of Kale tags.
+CELL_METADATA_TAGS = "tags"
+
+# `cell_type` value for cells Kale can turn into pipeline code.
+CELL_TYPE_CODE = "code"
+
+
+# --------------------------------------------------------------------------
+# Parsed-tag dictionary keys
+#
+# `parse_cell_metadata` produces this dict and `parse_notebook` consumes it,
+# so both sides must agree on every key.
+# --------------------------------------------------------------------------
+
+STEP_NAMES = "step_names"
+PREV_STEPS = "prev_steps"
+NOTEBOOK_NAMES = "notebook_names"
+# Carried from the referencing cell's metadata into the parsed tags under
+# the same name, so it serves both.
+NOTEBOOK_PATH = "notebook_path"
+ANNOTATIONS = "annotations"
+LABELS = "labels"
+LIMITS = "limits"
+BASE_IMAGE = "base_image"
+ENABLE_CACHING = "enable_caching"
+GENERATE_HTML_REPORT = "generate_html_report"
+
+# Field name of the pipeline-level defaults on `NotebookConfig`.
+STEPS_DEFAULTS = "steps_defaults"
+
+
+# --------------------------------------------------------------------------
+# Dynamically accessed Step attributes
+#
+# Looked up with getattr/hasattr, so a typo silently degrades to None
+# instead of raising.
+# --------------------------------------------------------------------------
+
+FNS_FREE_VARIABLES = "fns_free_variables"
+PARAMETERS = "parameters"
+
+
+# --------------------------------------------------------------------------
+# Default inferred types
+# --------------------------------------------------------------------------
+
+DEFAULT_VARIABLE_TYPE = "str"
+DEFAULT_ARTIFACT_TYPE = "Artifact"

--- a/kale/processors/nbprocessor.py
+++ b/kale/processors/nbprocessor.py
@@ -29,81 +29,38 @@ import networkx as nx
 from kale.common import astutils, flakeutils, graphutils, kfutils, utils
 from kale.config import Field
 from kale.pipeline import Pipeline, PipelineConfig
+from kale.processors.constants import (
+    ANNOTATIONS,
+    BASE_IMAGE,
+    CACHE_ENABLED,
+    CELL_METADATA_TAGS,
+    CELL_TYPE_CODE,
+    DEFAULT_ARTIFACT_TYPE,
+    DEFAULT_VARIABLE_TYPE,
+    ENABLE_CACHING,
+    FNS_FREE_VARIABLES,
+    FUNCTIONS_TAG,
+    GENERATE_HTML_REPORT,
+    IMPORT_TAG,
+    KALE_NB_METADATA_KEY,
+    KFP_ARTIFACT_TYPE_MAP,
+    LABELS,
+    LIMITS,
+    METRICS_TEMPLATE,
+    NOTEBOOK_NAMES,
+    NOTEBOOK_PATH,
+    PIPELINE_METRICS_TAG,
+    PIPELINE_PARAMETERS_TAG,
+    PREV_STEPS,
+    REPORT_ENABLED,
+    STEP_NAMES,
+    STEPS_DEFAULTS,
+    STEPS_DEFAULTS_LANGUAGE,
+    TAGS_LANGUAGE,
+)
 from kale.step import PipelineParam, Step, SubPipeline
 
 log = logging.getLogger(__name__)
-
-# fixme: Change the name of this key to `kale_metadata`
-KALE_NB_METADATA_KEY = "kubeflow_notebook"
-
-SKIP_TAG = r"^skip$"
-IMPORT_TAG = r"^imports$"
-FUNCTIONS_TAG = r"^functions$"
-PREV_TAG = r"^prev:[_a-z]([_a-z0-9]*)?$"
-STEP_TAG = r"^step:([_a-z]([_a-z0-9]*)?)?$"
-# A `notebook:<name>` cell references another notebook as a sub-pipeline. The
-# referenced path is carried in the cell metadata (`notebook_path`), not the tag.
-NOTEBOOK_TAG = r"^notebook:([_a-z]([_a-z0-9]*)?)?$"
-PIPELINE_PARAMETERS_TAG = r"^pipeline-parameters$"
-PIPELINE_METRICS_TAG = r"^pipeline-metrics$"
-# Annotations map to actual pod annotations that can be set via KFP SDK
-_segment = "[a-zA-Z0-9]+([a-zA-Z0-9-_.]*[a-zA-Z0-9])?"
-K8S_ANNOTATION_KEY = f"{_segment}([/]{_segment})?"
-ANNOTATION_TAG = rf"^annotation:{K8S_ANNOTATION_KEY}:(.*)$"
-LABEL_TAG = rf"^label:{K8S_ANNOTATION_KEY}:(.*)$"
-# Limits map to K8s limits, like CPU, Mem, GPU, ...
-# E.g.: limit:nvidia.com/gpu:2
-LIMITS_TAG = r"^limit:([_a-z-\.\/]+):([_a-zA-Z0-9\.]+)$"
-# Image tag for per-step Base image selection
-# E.g.: image:python:3.11-slim
-IMAGE_TAG = r"^image:(.+)$"
-# Cache tag for per-step caching control
-# E.g.: cache:enabled or cache:disabled
-CACHE_ENABLED = "enabled"
-CACHE_DISABLED = "disabled"
-CACHE_TAG = rf"^cache:({CACHE_ENABLED}|{CACHE_DISABLED})$"
-# Report tag for per-step HTML report generation control
-# E.g.: report:enabled or report:disabled
-REPORT_ENABLED = "enabled"
-REPORT_DISABLED = "disabled"
-REPORT_TAG = rf"^report:({REPORT_ENABLED}|{REPORT_DISABLED})$"
-
-_TAGS_LANGUAGE = [
-    SKIP_TAG,
-    IMPORT_TAG,
-    FUNCTIONS_TAG,
-    PREV_TAG,
-    STEP_TAG,
-    NOTEBOOK_TAG,
-    PIPELINE_PARAMETERS_TAG,
-    PIPELINE_METRICS_TAG,
-    ANNOTATION_TAG,
-    LABEL_TAG,
-    LIMITS_TAG,
-    IMAGE_TAG,
-    CACHE_TAG,
-    REPORT_TAG,
-]
-# These tags are applied to every step of the pipeline
-_STEPS_DEFAULTS_LANGUAGE = [ANNOTATION_TAG, LABEL_TAG, LIMITS_TAG, IMAGE_TAG, CACHE_TAG, REPORT_TAG]
-
-
-METRICS_TEMPLATE = """\
-from kale.common import kfputils as _kale_kfputils
-_kale_kfp_metrics = {
-%s
-}
-_kale_kfputils.generate_mlpipeline_metrics(_kale_kfp_metrics)\
-"""
-
-KFP_ARTIFACT_TYPE_MAP = {
-    "model": "Model",  # if "model" in var_name.lower()-> kfp.dsl.Model
-    "dataset": "Dataset",  # if "dataset" in var_name.lower()-> kfp.dsl.Dataset
-    "data": "Dataset",  # if "data" in var_name.lower()-> kfp.dsl.Dataset
-    "metrics": "Metrics",  # if "metrics" in var_name.lower()-> kfp.dsl.Metrics
-    "classification": "ClassificationMetrics",
-    r"a-zA-Z0-9_": "Artifact",  # default for any other variable
-}
 
 
 def get_annotation_or_label_from_tag(tag_parts):
@@ -153,7 +110,7 @@ class NotebookConfig(PipelineConfig):
         return self.notebook_path
 
     def _preprocess(self, kwargs):
-        kwargs["steps_defaults"] = self._parse_steps_defaults(kwargs.get("steps_defaults"))
+        kwargs[STEPS_DEFAULTS] = self._parse_steps_defaults(kwargs.get(STEPS_DEFAULTS))
 
     def _parse_steps_defaults(self, steps_defaults):
         """Parse common step configuration defined in the metadata."""
@@ -163,7 +120,7 @@ class NotebookConfig(PipelineConfig):
             return steps_defaults
 
         for c in steps_defaults:
-            if any(re.match(_c, c) for _c in _STEPS_DEFAULTS_LANGUAGE) is False:
+            if any(re.match(_c, c) for _c in STEPS_DEFAULTS_LANGUAGE) is False:
                 raise ValueError(f"Unrecognized common step configuration: {c}")
 
             parts = c.split(":")
@@ -177,24 +134,24 @@ class NotebookConfig(PipelineConfig):
                 result[result_key][key] = value
 
             if conf_type == "limit":
-                if "limits" not in result:
-                    result["limits"] = {}
+                if LIMITS not in result:
+                    result[LIMITS] = {}
                 key, value = get_limit_from_tag(parts)
-                result["limits"][key] = value
+                result[LIMITS][key] = value
 
             if conf_type == "image":
                 # Image tag value is the rest after 'image:'
-                result["base_image"] = ":".join(parts)
+                result[BASE_IMAGE] = ":".join(parts)
 
             if conf_type == "cache":
                 # Cache value is 'enabled' or 'disabled'
                 cache_value = parts.pop(0)
-                result["enable_caching"] = cache_value == CACHE_ENABLED
+                result[ENABLE_CACHING] = cache_value == CACHE_ENABLED
 
             if conf_type == "report":
                 # Report value is 'enabled' or 'disabled'
                 report_value = parts.pop(0)
-                result["generate_html_report"] = report_value == REPORT_ENABLED
+                result[GENERATE_HTML_REPORT] = report_value == REPORT_ENABLED
         return result
 
 
@@ -236,7 +193,7 @@ class NotebookProcessor:
         self.notebook = self._read_notebook()
 
         nb_metadata = self.notebook.metadata.get(KALE_NB_METADATA_KEY, {})
-        nb_metadata.update({"notebook_path": nb_path})
+        nb_metadata.update({NOTEBOOK_PATH: nb_path})
         if nb_metadata_overrides:
             nb_metadata.update(nb_metadata_overrides)
 
@@ -271,8 +228,8 @@ class NotebookProcessor:
             _pod_defaults_labels = kfutils.find_poddefault_labels()
         except Exception as e:
             log.warning("Could not retrieve PodDefaults. Reason: %s", e)
-        self.pipeline.config.steps_defaults["labels"] = {
-            **self.pipeline.config.steps_defaults.get("labels", {}),
+        self.pipeline.config.steps_defaults[LABELS] = {
+            **self.pipeline.config.steps_defaults.get(LABELS, {}),
             **_pod_defaults_labels,
         }
 
@@ -354,23 +311,23 @@ class NotebookProcessor:
         }
 
         for c in self.notebook.cells:
-            if c.cell_type != "code":
+            if c.cell_type != CELL_TYPE_CODE:
                 continue
 
             tags = self.parse_cell_metadata(c.metadata)
 
-            if len(tags["step_names"]) > 1:
+            if len(tags[STEP_NAMES]) > 1:
                 raise NotImplementedError(
                     "Kale does not yet support multiple"
                     " step names in a single notebook"
                     " cell. One notebook cell was found"
-                    " with {}  step names".format(tags["step_names"])
+                    f" with {tags[STEP_NAMES]}  step names"
                 )
 
             # get the step name from the tags
-            step_name = tags["step_names"][0] if len(tags["step_names"]) > 0 else None
+            step_name = tags[STEP_NAMES][0] if len(tags[STEP_NAMES]) > 0 else None
 
-            if tags["notebook_names"]:
+            if tags[NOTEBOOK_NAMES]:
                 # a reference cell holds no code of its own, and dropping it
                 # silently is how you lose work when a code cell is switched to
                 # the Notebook type. Comments are fine, the UI writes one.
@@ -390,7 +347,7 @@ class NotebookProcessor:
                         " a `step:` cell that owns it (found another `notebook:`"
                         " cell first)."
                     )
-                self._add_notebook_reference(tags["notebook_names"][0], tags.get("notebook_path"))
+                self._add_notebook_reference(tags[NOTEBOOK_NAMES][0], tags.get(NOTEBOOK_PATH))
                 prev_step_name = None
                 awaiting_step = True
                 continue
@@ -441,21 +398,19 @@ class NotebookProcessor:
                         source=pending_sources + [c.source],
                         ins=[],
                         outs=[],
-                        limits=tags.get("limits", {}),
-                        labels=tags.get("labels", {}),
-                        annotations=tags.get("annotations", {}),
-                        base_image=tags.get("base_image", ""),
-                        enable_caching=tags.get("enable_caching"),
-                        generate_html_report=tags.get("generate_html_report"),
+                        limits=tags.get(LIMITS, {}),
+                        labels=tags.get(LABELS, {}),
+                        annotations=tags.get(ANNOTATIONS, {}),
+                        base_image=tags.get(BASE_IMAGE, ""),
+                        enable_caching=tags.get(ENABLE_CACHING),
+                        generate_html_report=tags.get(GENERATE_HTML_REPORT),
                     )
                     self.pipeline.add_step(step)
-                    for _prev_step in tags["prev_steps"]:
+                    for _prev_step in tags[PREV_STEPS]:
                         if _prev_step not in self.pipeline.nodes:
                             raise ValueError(
-                                "Step {} does not exist. It was "
-                                "defined as previous step of {}".format(
-                                    _prev_step, tags["step_names"]
-                                )
+                                f"Step {_prev_step} does not exist. It was "
+                                f"defined as previous step of {tags[STEP_NAMES]}"
                             )
                         self.pipeline.add_edge(_prev_step, step_name)
                 else:
@@ -655,7 +610,7 @@ class NotebookProcessor:
         """Parse a notebook's cell's metadata field.
 
         The Kale UI writes specific tags inside the 'tags' field, as a list
-        of string tags. Supported tags are defined by _TAGS_LANGUAGE.
+        of string tags. Supported tags are defined by TAGS_LANGUAGE.
 
         Args:
             metadata (dict): a dict containing a notebook's cell's metadata
@@ -667,10 +622,10 @@ class NotebookProcessor:
 
         # `step_names` is a list because a notebook cell might be assigned to
         # more than one Pipeline step.
-        parsed_tags["step_names"] = []
-        parsed_tags["prev_steps"] = []
+        parsed_tags[STEP_NAMES] = []
+        parsed_tags[PREV_STEPS] = []
         # names of notebooks referenced by `notebook:` cells (sub-pipelines)
-        parsed_tags["notebook_names"] = []
+        parsed_tags[NOTEBOOK_NAMES] = []
         # define intermediate variables so that dicts are not added to a steps
         # when they are empty
         cell_annotations = {}
@@ -681,14 +636,14 @@ class NotebookProcessor:
         cell_generate_html_report = None
 
         # the notebook cell was not tagged
-        if "tags" not in metadata or len(metadata["tags"]) == 0:
+        if CELL_METADATA_TAGS not in metadata or len(metadata[CELL_METADATA_TAGS]) == 0:
             return parsed_tags
 
-        for t in metadata["tags"]:
+        for t in metadata[CELL_METADATA_TAGS]:
             if not isinstance(t, str):
                 raise ValueError(f"Tags must be string. Found tag {t} of type {type(t)}")
             # Check that the tag is defined by the Kale tagging language
-            if any(re.match(_t, t) for _t in _TAGS_LANGUAGE) is False:
+            if any(re.match(_t, t) for _t in TAGS_LANGUAGE) is False:
                 raise ValueError(f"Unrecognized tag: {t}")
 
             # Special tags have a specific effect on the cell they belong to.
@@ -711,7 +666,7 @@ class NotebookProcessor:
                 "functions",
             ]
             if t in special_tags:
-                parsed_tags["step_names"] = [t]
+                parsed_tags[STEP_NAMES] = [t]
                 return parsed_tags
 
             # now only `step` and `prev` tags remain to be parsed.
@@ -747,38 +702,38 @@ class NotebookProcessor:
             # name of the referenced notebook, compiled as a sub-pipeline. Its
             # path comes from the cell metadata, not from the tag.
             if tag_name == "notebook":
-                parsed_tags["notebook_names"].append(tag_parts.pop(0))
-                parsed_tags["notebook_path"] = metadata.get("notebook_path")
+                parsed_tags[NOTEBOOK_NAMES].append(tag_parts.pop(0))
+                parsed_tags[NOTEBOOK_PATH] = metadata.get(NOTEBOOK_PATH)
 
             # name of the future Pipeline step
             if tag_name in ["step"]:
                 step_name = tag_parts.pop(0)
-                parsed_tags["step_names"].append(step_name)
+                parsed_tags[STEP_NAMES].append(step_name)
             # name(s) of the father Pipeline step(s)
             if tag_name == "prev":
                 prev_step_name = tag_parts.pop(0)
-                parsed_tags["prev_steps"].append(prev_step_name)
+                parsed_tags[PREV_STEPS].append(prev_step_name)
 
-        if not parsed_tags["step_names"] and parsed_tags["prev_steps"]:
+        if not parsed_tags[STEP_NAMES] and parsed_tags[PREV_STEPS]:
             raise ValueError(
                 "A cell can not provide `prev` annotations without "
                 "providing a `step` annotation as well"
             )
-        missing_step_names = not parsed_tags["step_names"]
+        missing_step_names = not parsed_tags[STEP_NAMES]
         if cell_annotations:
             if missing_step_names:
                 raise ValueError(
                     "A cell can not provide Pod annotations in a cell"
                     " that does not declare a step name."
                 )
-            parsed_tags["annotations"] = cell_annotations
+            parsed_tags[ANNOTATIONS] = cell_annotations
 
         if cell_labels:
             if missing_step_names:
                 raise ValueError(
                     "A cell can not provide Pod labels in a cell that does not declare a step name."
                 )
-            parsed_tags["labels"] = cell_labels
+            parsed_tags[LABELS] = cell_labels
 
         if cell_limits:
             if missing_step_names:
@@ -786,7 +741,7 @@ class NotebookProcessor:
                     "A cell can not provide Pod resource limits in a"
                     " cell that does not declare a step name."
                 )
-            parsed_tags["limits"] = cell_limits
+            parsed_tags[LIMITS] = cell_limits
 
         if cell_base_image:
             if missing_step_names:
@@ -794,7 +749,7 @@ class NotebookProcessor:
                     "A cell can not provide a base image in a"
                     " cell that does not declare a step name."
                 )
-            parsed_tags["base_image"] = cell_base_image
+            parsed_tags[BASE_IMAGE] = cell_base_image
 
         if cell_enable_caching is not None:
             if missing_step_names:
@@ -802,7 +757,7 @@ class NotebookProcessor:
                     "A cell can not provide caching control in a"
                     " cell that does not declare a step name."
                 )
-            parsed_tags["enable_caching"] = cell_enable_caching
+            parsed_tags[ENABLE_CACHING] = cell_enable_caching
 
         if cell_generate_html_report is not None:
             if missing_step_names:
@@ -810,7 +765,7 @@ class NotebookProcessor:
                     "A cell can not provide HTML report control in a"
                     " cell that does not declare a step name."
                 )
-            parsed_tags["generate_html_report"] = cell_generate_html_report
+            parsed_tags[GENERATE_HTML_REPORT] = cell_generate_html_report
         return parsed_tags
 
     def get_pipeline_parameters_source(self):
@@ -828,19 +783,19 @@ class NotebookProcessor:
         # check that the pipeline metrics tag is only assigned to cells at
         # the end of the notebook
         detected = False
-        tags = _TAGS_LANGUAGE[:]
+        tags = TAGS_LANGUAGE[:]
         tags.remove(PIPELINE_METRICS_TAG)
 
         for c in self.notebook.cells:
             # parse only source code cells
-            if c.cell_type != "code":
+            if c.cell_type != CELL_TYPE_CODE:
                 continue
 
             # if we see a pipeline-metrics tag, set the flag
             if (
-                "tags" in c.metadata
-                and len(c.metadata["tags"]) > 0
-                and any(re.match(PIPELINE_METRICS_TAG, t) for t in c.metadata["tags"])
+                CELL_METADATA_TAGS in c.metadata
+                and len(c.metadata[CELL_METADATA_TAGS]) > 0
+                and any(re.match(PIPELINE_METRICS_TAG, t) for t in c.metadata[CELL_METADATA_TAGS])
             ):
                 detected = True
                 continue
@@ -849,9 +804,11 @@ class NotebookProcessor:
             # language, then raise error
             if (
                 detected
-                and "tags" in c.metadata
-                and len(c.metadata["tags"]) > 0
-                and any(any(re.match(tag, t) for t in c.metadata["tags"]) for tag in tags)
+                and CELL_METADATA_TAGS in c.metadata
+                and len(c.metadata[CELL_METADATA_TAGS]) > 0
+                and any(
+                    any(re.match(tag, t) for t in c.metadata[CELL_METADATA_TAGS]) for tag in tags
+                )
             ):
                 raise ValueError(
                     "Tag pipeline-metrics tag must be placed on a "
@@ -889,24 +846,27 @@ class NotebookProcessor:
         detected = False
         source = ""
 
-        language = _TAGS_LANGUAGE[:]
+        language = TAGS_LANGUAGE[:]
         language.remove(search_tag)
 
         for c in self.notebook.cells:
             # parse only source code cells
-            if c.cell_type != "code":
+            if c.cell_type != CELL_TYPE_CODE:
                 continue
             # in case the previous cell was a `search_tag` cell and this
             # cell is not any other tag of the tag language:
             if detected and (
-                ("tags" not in c.metadata or len(c.metadata["tags"]) == 0)
-                or all(not any(re.match(tag, t) for t in c.metadata["tags"]) for tag in language)
+                ("tags" not in c.metadata or len(c.metadata[CELL_METADATA_TAGS]) == 0)
+                or all(
+                    not any(re.match(tag, t) for t in c.metadata[CELL_METADATA_TAGS])
+                    for tag in language
+                )
             ):
                 source += "\n" + c.source
             elif (
-                "tags" in c.metadata
-                and len(c.metadata["tags"]) > 0
-                and any(re.match(search_tag, t) for t in c.metadata["tags"])
+                CELL_METADATA_TAGS in c.metadata
+                and len(c.metadata[CELL_METADATA_TAGS]) > 0
+                and any(re.match(search_tag, t) for t in c.metadata[CELL_METADATA_TAGS])
             ):
                 source += "\n" + c.source
                 detected = True
@@ -999,7 +959,7 @@ class NotebookProcessor:
 
     def _ensure_fns_free_variables(self, anc_step, anc_source: str, imports_and_functions: str):
         """Lazily compute ancestor functions' free vars if missing."""
-        if not getattr(anc_step, "fns_free_variables", None):
+        if not getattr(anc_step, FNS_FREE_VARIABLES, None):
             anc_step.fns_free_variables = self._detect_fns_free_variables(
                 anc_source, imports_and_functions, self.pipeline.pipeline_parameters
             )
@@ -1013,7 +973,7 @@ class NotebookProcessor:
         Additionally, propagate transitive free variables via earlier ancestors
         of anc_step.
         """
-        anc_fns_free_vars = getattr(anc_step, "fns_free_variables", {})
+        anc_fns_free_vars = getattr(anc_step, FNS_FREE_VARIABLES, {})
         if fn_name not in anc_fns_free_vars:
             return
         fn_free_vars, _ = anc_fns_free_vars[fn_name]
@@ -1038,7 +998,7 @@ class NotebookProcessor:
             ea_source = "\n".join(ea_step.source)
             # Ensure their fns_free_variables are computed
             self._ensure_fns_free_variables(ea_step, ea_source, self.get_imports_and_functions())
-            ea_fns_free_vars = getattr(ea_step, "fns_free_variables", {})
+            ea_fns_free_vars = getattr(ea_step, FNS_FREE_VARIABLES, {})
             # We iterate over a snapshot of aggregated to allow growth
             # during the loop
             to_check = list(aggregated)
@@ -1058,7 +1018,7 @@ class NotebookProcessor:
         for fv_name in aggregated:
             if fv_name not in step.ins:
                 step.ins.append(fv_name)
-            inferred_type = "str"
+            inferred_type = DEFAULT_VARIABLE_TYPE
             is_artifact = False
             for key, kfp_type in KFP_ARTIFACT_TYPE_MAP.items():
                 if key in fv_name.lower():
@@ -1147,7 +1107,7 @@ class NotebookProcessor:
                 outs = ins_left.intersection(marshal_candidates)
                 for out_name in outs:
                     # Heuristic for type inference:
-                    inferred_type = "str"  # Default
+                    inferred_type = DEFAULT_VARIABLE_TYPE  # Default
                     is_artifact = False
                     for key, kfp_type in KFP_ARTIFACT_TYPE_MAP.items():
                         if key in out_name.lower():
@@ -1214,7 +1174,7 @@ class NotebookProcessor:
                 and trailing_var in astutils.get_marshal_candidates(step_source)
                 and trailing_var not in self.pipeline.pipeline_parameters
             ):
-                inferred_type = "Artifact"
+                inferred_type = DEFAULT_ARTIFACT_TYPE
                 for key, kfp_type in KFP_ARTIFACT_TYPE_MAP.items():
                     if key in trailing_var.lower():
                         inferred_type = kfp_type

--- a/kale/processors/nbprocessor.py
+++ b/kale/processors/nbprocessor.py
@@ -49,6 +49,7 @@ from kale.processors.constants import (
     METRICS_TEMPLATE,
     NOTEBOOK_NAMES,
     NOTEBOOK_PATH,
+    PARAMETERS,
     PIPELINE_METRICS_TAG,
     PIPELINE_PARAMETERS_TAG,
     PREV_STEPS,
@@ -56,6 +57,7 @@ from kale.processors.constants import (
     STEP_NAMES,
     STEPS_DEFAULTS,
     STEPS_DEFAULTS_LANGUAGE,
+    TAG_SEPARATOR,
     TAGS_LANGUAGE,
 )
 from kale.step import PipelineParam, Step, SubPipeline
@@ -123,7 +125,7 @@ class NotebookConfig(PipelineConfig):
             if any(re.match(_c, c) for _c in STEPS_DEFAULTS_LANGUAGE) is False:
                 raise ValueError(f"Unrecognized common step configuration: {c}")
 
-            parts = c.split(":")
+            parts = c.split(TAG_SEPARATOR)
 
             conf_type = parts.pop(0)
             if conf_type in ["annotation", "label"]:
@@ -141,7 +143,7 @@ class NotebookConfig(PipelineConfig):
 
             if conf_type == "image":
                 # Image tag value is the rest after 'image:'
-                result[BASE_IMAGE] = ":".join(parts)
+                result[BASE_IMAGE] = TAG_SEPARATOR.join(parts)
 
             if conf_type == "cache":
                 # Cache value is 'enabled' or 'disabled'
@@ -670,7 +672,7 @@ class NotebookProcessor:
                 return parsed_tags
 
             # now only `step` and `prev` tags remain to be parsed.
-            tag_parts = t.split(":")
+            tag_parts = t.split(TAG_SEPARATOR)
             tag_name = tag_parts.pop(0)
 
             if tag_name == "annotation":
@@ -687,7 +689,7 @@ class NotebookProcessor:
 
             if tag_name == "image":
                 # Image value is the rest after 'image:'
-                cell_base_image = ":".join(tag_parts)
+                cell_base_image = TAG_SEPARATOR.join(tag_parts)
 
             if tag_name == "cache":
                 # Cache value is 'enabled' or 'disabled'
@@ -856,7 +858,7 @@ class NotebookProcessor:
             # in case the previous cell was a `search_tag` cell and this
             # cell is not any other tag of the tag language:
             if detected and (
-                ("tags" not in c.metadata or len(c.metadata[CELL_METADATA_TAGS]) == 0)
+                (CELL_METADATA_TAGS not in c.metadata or len(c.metadata[CELL_METADATA_TAGS]) == 0)
                 or all(
                     not any(re.match(tag, t) for t in c.metadata[CELL_METADATA_TAGS])
                     for tag in language
@@ -1148,10 +1150,10 @@ class NotebookProcessor:
                     # Propagate pipeline parameters from the ancestor step
                     # whenever we call a function it provides (directly or via
                     # marshal candidates).
-                    if getattr(anc_step, "parameters", None) and (
+                    if getattr(anc_step, PARAMETERS, None) and (
                         fn_call in anc_fns_free_vars or fn_call in marshal_candidates
                     ):
-                        if not hasattr(step, "parameters") or step.parameters is None:
+                        if not hasattr(step, PARAMETERS) or step.parameters is None:
                             step.parameters = {}
                         for _pname, _pval in anc_step.parameters.items():
                             if _pname not in step.parameters:


### PR DESCRIPTION
## What this does

Moves the constants out of `nbprocessor.py` into a new `kale/processors/constants.py`, and replaces the inline magic strings with those constants.

Part of #879 — this is the "start small" step @ada333 asked for.

## Why

`nbprocessor.py` had module-level constants at the top *and* a lot of repeated string literals inline: `"step_names"` (10x), `"tags"` (11x), `"limits"` (5x), `"prev_steps"` (4x), `"labels"` (4x), `"enable_caching"` (3x), `"base_image"` (3x), `"fns_free_variables"` (3x), `"code"` (3x), and others. A typo in any of them fails silently — a wrong dict key reads as "not set", and a wrong `getattr` name returns `None` — rather than raising.

## How it's grouped

Rather than one flat list, the new module groups by what each string actually *is*, since they aren't interchangeable:

- **Notebook JSON keys** — read from the `.ipynb` structure (`KALE_NB_METADATA_KEY`, `CELL_METADATA_TAGS`, `CELL_TYPE_CODE`).
- **Cell tag language** — the user-facing tag regexes and the two tag lists.
- **Parsed-tag dictionary keys** — `STEP_NAMES`, `PREV_STEPS`, `LIMITS`, `LABELS`, `ANNOTATIONS`, `BASE_IMAGE`, `ENABLE_CACHING`. These are the contract between `parse_cell_metadata` (which produces the dict) and `parse_notebook` (which consumes it), so both sides now reference the same names.
- **Dynamically accessed `Step` attributes** — `FNS_FREE_VARIABLES`, `PARAMETERS`, looked up via `getattr`/`hasattr`.
- **Templates and type maps** — `METRICS_TEMPLATE`, `KFP_ARTIFACT_TYPE_MAP`, plus `DEFAULT_VARIABLE_TYPE` / `DEFAULT_ARTIFACT_TYPE` for the `"str"` / `"Artifact"` fallbacks.

## Testing

- `pytest kale/tests/unit_tests` → **244 passed**
- `ruff check kale` and `ruff format --check kale` → clean
- Verified as a pure move: I compared every constant defined on `main` against the new module programmatically — all **21 are identical** in value. No behaviour change.

## Two judgment calls, happy to change either

1. **`_TAGS_LANGUAGE` → `TAGS_LANGUAGE`** (and `_STEPS_DEFAULTS_LANGUAGE` → `STEPS_DEFAULTS_LANGUAGE`). The leading underscore marked them module-private; now that they're imported across modules that's no longer accurate. Say the word if you'd rather keep the underscore.
2. **Two `.format()` calls became f-strings.** Not gratuitous: with the quoted dict keys replaced by constants, ruff's `UP032` became applicable and `ruff check` fails without it. They're the only non-mechanical lines in the diff.

Follow-ups from #879 (extracting the tag parsing, dependency analysis and metrics into their own modules) are deliberately left out of this PR.
