### PR TITLE
fix(ci): scope PR title check concurrency to the pull request

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -11,7 +11,9 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # pull_request_target sets github.ref to the base branch, so keying on it alone
+  # puts every open PR in one group and they cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

`Check PR Title` shows red on PRs whose titles are perfectly valid — e.g. #928 and #929.

The workflow's concurrency group is keyed on `github.ref`:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: true
```

But this workflow triggers on `pull_request_target`, where `github.ref` is the **base branch**, not the PR ref. So every open PR lands in one shared group named `Check PR Title-refs/heads/main`, and with `cancel-in-progress: true` each new PR event cancels the title check still running for all the others. A cancelled run surfaces as a failed check.

Run history for the workflow shows the pattern clearly — the same branches have both `success` and `cancelled` runs, and the newest run is the one that reports:

| branch | runs |
|---|---|
| `dependabot/.../dompurify-3.4.13` | 2 × cancelled |
| `dependabot/.../js-yaml-3.15.1` | 1 × cancelled, 1 × success |
| `issue-843-add-pvc-mount` | 8 × success (uncontested) |

The check itself is fine — `ignoreLabels: dependencies` works as intended whenever the run is actually allowed to finish.

## Fix

Key the group on the pull request number, which is what [`build_labextension.yml`](https://github.com/kubeflow/kale/blob/main/.github/workflows/build_labextension.yml#L10) already does:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```

The `|| github.ref` fallback keeps the expression valid for any non-PR event.

## Notes

This is one of two unrelated causes behind the currently-red dependency PRs. The other — Dependabot writing lockfiles with a different Yarn than CI installs with — is #933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
