### PR TITLE
fix(ci): pin Yarn so Dependabot lockfile updates match jlpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
         build \
         kfp-build kfp-serve kfp-compile kfp-run \
         kfp-dev-setup kfp-dev-start kfp-dev-stop kfp-dev-delete kfp-dev-status kfp-dev-upgrade \
-        clean clean-venv lock lock-upgrade check-uv \
+        clean clean-venv lock lock-upgrade check-uv check-yarn-version \
         jupyter jupyter-kfp watch-labextension \
         docker-build docker-run \
         docs docs-serve docs-clean \
@@ -34,6 +34,24 @@ check-uv: ## Verify uv is installed
 		curl -LsSf https://astral.sh/uv/install.sh | sh; \
 	}
 
+check-yarn-version: ## Verify jlpm's Yarn matches the packageManager pin
+	@pinned=$$(sed -n 's/.*"packageManager": *"yarn@\([^"]*\)".*/\1/p' labextension/package.json); \
+	actual=$$($(JLPM) --version 2>/dev/null | tail -1); \
+	if [ -z "$$pinned" ]; then \
+		printf "$(YELLOW)No packageManager pin found in labextension/package.json.\n$(NC)"; \
+		exit 1; \
+	fi; \
+	if [ "$$pinned" != "$$actual" ]; then \
+		printf "$(YELLOW)Yarn mismatch: package.json pins yarn@$$pinned, jlpm provides $$actual.\n$(NC)"; \
+		printf "$(YELLOW)Dependabot activates the pinned version via Corepack, so a mismatch makes its\n$(NC)"; \
+		printf "$(YELLOW)yarn.lock updates fail 'jlpm install --immutable' in CI.\n$(NC)"; \
+		printf "$(YELLOW)Fix: set packageManager to yarn@$$actual in labextension/package.json and\n$(NC)"; \
+		printf "$(YELLOW)labextension/ui-tests/package.json, then regenerate both lockfiles with\n$(NC)"; \
+		printf "$(YELLOW)'jlpm install --mode=update-lockfile'.\n$(NC)"; \
+		exit 1; \
+	fi; \
+	printf "$(GREEN)Yarn $$actual (jlpm) matches the packageManager pin\n$(NC)"
+
 ##@ Installation
 
 dev: check-uv ## Set up development environment
@@ -42,6 +60,8 @@ dev: check-uv ## Set up development environment
 	@# Skip the hatch jupyter-builder hook — we build the labextension explicitly below
 	SKIP_JUPYTER_BUILDER=1 $(UV) sync --all-extras
 	@# Step 2: Build labextension (requires jlpm from step 1)
+	@# Guard first: a jlpm/packageManager mismatch silently breaks Dependabot's lockfile updates
+	@$(MAKE) --no-print-directory check-yarn-version
 	cd labextension && $(JLPM) install
 	@# Clean tsbuildinfo cache before build (fixes incremental build issues after make clean)
 	cd labextension && $(JLPM) clean:lib

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -15,6 +15,7 @@
   "engines": {
     "node": ">=22"
   },
+  "packageManager": "yarn@3.5.0",
   "author": {
     "name": "Stefano Fioravanzo",
     "email": "stefano.fioravanzo@gmail.com"

--- a/labextension/ui-tests/package.json
+++ b/labextension/ui-tests/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "JupyterLab jupyterlab-kubeflow-kale Integration Tests",
   "private": true,
+  "packageManager": "yarn@3.5.0",
   "scripts": {
     "start": "cd ../.. && uv run jupyter lab --config labextension/ui-tests/jupyter_server_test_config.py",
     "test": "jlpm playwright test",


### PR DESCRIPTION
## Problem

Every Dependabot PR that touches `labextension/yarn.lock` fails in `make dev`, regardless of which dependency is being bumped — see #928 and #930:

```
➤ YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
make: *** [Makefile:45: dev] Error 1
```

The cause is a Yarn version mismatch, not anything about the dependencies.

`make dev` installs the labextension with `jlpm install` — the Yarn bundled inside JupyterLab, which is **3.5.0** for the `jupyterlab 4.5.7` pinned in `uv.lock`. Under `CI=1` that install is `--immutable`. Dependabot regenerates the lockfile with its own **Yarn 4.x**. The two disagree on the hash of the auto-applied `typescript` compat patch:

| Yarn | `typescript@patch:` resolution |
|---|---|
| 3.5.0 (jlpm → CI) | `...&hash=85af82` ← what `main` has |
| 4.10.3 (Dependabot) | `...&hash=5786d5` ← what the PRs have |

I confirmed this by generating a lockfile for `typescript: ~5.9.2` under each Yarn version in a throwaway project, and then reproducing the exact CI failure locally against #930's real lockfile.

On #930 this is **2 wrong lines out of a 68-line diff** — the mermaid bump itself is entirely valid. Regenerating that same bump with Yarn 3.5.0 makes `--immutable` pass (exit 0) and leaves no delta beyond those two lines.

## Fix

Declare the Yarn version in both `package.json` files:

```json
"packageManager": "yarn@3.5.0"
```

Dependabot's npm/yarn updater reads `packageManager` and activates that exact version through Corepack, so its lockfile updates will match what `jlpm` installs with.

A `resolutions` override is not an alternative — I tested `"typescript": "npm:5.9.3"` and the compat patch entry is still emitted under both Yarn versions. Pinning the version is the only fix.

## The guard

`jupyterlab` is constrained only as `>=4.0.0,<5`, so a future bump could change jlpm's bundled Yarn and silently re-break Dependabot with no obvious connection to the cause. The new `check-yarn-version` target compares `jlpm --version` against the pin and fails with the remediation steps. It runs from `dev` **before** `jlpm install`, so it fails fast:

```
$ make check-yarn-version
Yarn mismatch: package.json pins yarn@4.10.3, jlpm provides 3.5.0.
Dependabot activates the pinned version via Corepack, so a mismatch makes its
yarn.lock updates fail 'jlpm install --immutable' in CI.
Fix: set packageManager to yarn@3.5.0 in labextension/package.json and
labextension/ui-tests/package.json, then regenerate both lockfiles with
'jlpm install --mode=update-lockfile'.
```

## Verification

- `jlpm install --immutable` passes against **both** lockfiles with the pin added, and modifies neither — the pin introduces no drift of its own.
- Guard exercised in both directions: exit 0 on the correct pin, exit 1 with the message above when deliberately mismatched.
- Re-checked `labextension/ui-tests/yarn.lock` after #927 merged; still immutable-clean.

## Follow-up

The proof that Corepack honors the pin is #928 / #930 coming back green. Those two need `@dependabot recreate` (not `rebase`) once this lands, since the lockfile has to be regenerated rather than replayed. #929 only needs a rebase — its diff is already clean.

Dependabot's Corepack path sits behind an internal experiment flag that I can't inspect from outside. If it turns out not to be active here, the fallback is a workflow that regenerates the lock with `jlpm` on Dependabot branches and pushes the correction. The guard is worth having either way.

Worth considering separately: there's no `.github/dependabot.yml`, so these arrive one PR per security alert. A config with `groups` would collapse npm bumps into one PR per directory — one lockfile to get right instead of N.

## Notes

Companion to #932, which fixes the unrelated `Check PR Title` failures on the same PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
