### PR TITLE
fix(frontend): block invalid step names instead of only warning

### DIFF
--- a/labextension/src/components/Input.tsx
+++ b/labextension/src/components/Input.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { styled } from '@mui/material/styles';
 
@@ -70,6 +70,13 @@ export const Input: React.FunctionComponent<IInputProps> = props => {
   } = props;
 
   const [beforeUpdateError, setBeforeUpdateError] = useState(false);
+  // Tracks exactly what's in the text field, which may briefly diverge from
+  // `propsValue` while its content fails validation (see handleChange).
+  const [localValue, setLocalValue] = useState(String(propsValue));
+
+  useEffect(() => {
+    setLocalValue(String(propsValue));
+  }, [propsValue]);
 
   const getRegex = (): string | RegExp | undefined => {
     if (regex) {
@@ -97,14 +104,17 @@ export const Input: React.FunctionComponent<IInputProps> = props => {
     return undefined;
   };
 
-  const value = String(propsValue);
+  const value = localValue;
   const regexPattern = getRegex();
-  const regexError =
-    regexPattern !== undefined && value !== ''
-      ? !new RegExp(regexPattern).test(value)
-      : false;
-  const maxLengthError =
-    maxLength !== undefined ? value.length > maxLength : false;
+  const isRegexValid = (candidate: string): boolean =>
+    regexPattern === undefined ||
+    candidate === '' ||
+    new RegExp(regexPattern).test(candidate);
+  const isMaxLengthValid = (candidate: string): boolean =>
+    maxLength === undefined || candidate.length <= maxLength;
+
+  const regexError = !isRegexValid(value);
+  const maxLengthError = !isMaxLengthValid(value);
   const error = regexError || maxLengthError || beforeUpdateError;
 
   const getErrorMessage = (): string | undefined => {
@@ -119,9 +129,24 @@ export const Input: React.FunctionComponent<IInputProps> = props => {
 
   const handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = evt.target.value;
+    setLocalValue(newValue);
+
+    let hasBeforeUpdateError = false;
     if (onBeforeUpdate) {
-      const hasError = onBeforeUpdate(newValue);
-      setBeforeUpdateError(hasError);
+      hasBeforeUpdateError = onBeforeUpdate(newValue);
+      setBeforeUpdateError(hasBeforeUpdateError);
+    }
+
+    // Never persist a value that fails validation — otherwise it can be
+    // saved into the notebook (and wired up as a step dependency) only to
+    // break pipeline compilation later. The invalid text stays visible
+    // locally, with the error styling/message, so the user can fix it.
+    if (
+      !isRegexValid(newValue) ||
+      !isMaxLengthValid(newValue) ||
+      hasBeforeUpdateError
+    ) {
+      return;
     }
     updateValue(newValue, inputIndex || 0);
   };

--- a/labextension/src/widgets/cell-metadata/constants.ts
+++ b/labextension/src/widgets/cell-metadata/constants.ts
@@ -65,4 +65,6 @@ export const RESERVED_CELL_NAMES_CHIP_COLOR: { [id: string]: string } = {
 };
 
 export const STEP_NAME_ERROR_MSG =
-  "Step name must consist of lower case alphanumeric characters or '_', and can not start with a digit.";
+  "Step name must consist of lower case alphanumeric characters or '_', and can not start with a digit. " +
+  'Unlike pipeline names, hyphens are not allowed here because step names become Python ' +
+  'identifiers in the generated pipeline code.';


### PR DESCRIPTION
## Summary
- `Input.tsx`'s `handleChange` called `updateValue()` unconditionally, regardless of whether the typed value failed the regex/maxLength/`onBeforeUpdate` validation. For the pipeline-step-name field this meant a name like `add-strings` got saved into the notebook cell metadata (and could be selected as a dependency by other steps) even though it's invalid — it would only fail later, at pipeline compile time, with a confusing error, since step names are spliced into the generated code as Python function/variable identifiers (so hyphens can't be allowed there, unlike pipeline names which follow DNS-1123 naming and do allow hyphens).
- `Input` now tracks the field's live text in local state, separate from the committed value passed via `updateValue`. Invalid text still renders in the field with the existing red error styling/message (so users can see and fix it), but it's never propagated to `updateValue`/notebook metadata. This also incidentally fixes the same class of bug for duplicate step names (the `onBeforeUpdate` check), which had the identical problem.
- Reworded `STEP_NAME_ERROR_MSG` to explain *why* hyphens aren't allowed for step names (unlike pipeline names), instead of just stating the rule.

Fixes #882

## Test plan
- [x] `tsc --noEmit`, `eslint:check`, `prettier:check` all pass.
- [x] `jest` passes (no labextension component tests exist yet in this repo to extend).
- [x] Manually verified in a running JupyterLab + Kale sidebar: typing a hyphenated step name (e.g. `add-strings`) now shows the reworded error message live and is never committed (no tag chip appears above the cell, confirmed against the notebook's actual cell metadata). Fixing it to a valid name (e.g. `add_strings`) commits normally and shows the step chip.