### PR TITLE
fix(backend): stop CLI defaults from overriding the notebook's pipeline name

### DIFF
--- a/kale/cli.py
+++ b/kale/cli.py
@@ -39,6 +39,10 @@ is provided both in the Notebook metadata and from CLI, the CLI parameter
 will take precedence.\n
 """
 
+# Used only when neither the notebook metadata nor the CLI names one.
+DEFAULT_PIPELINE_NAME = "kale-pipeline"
+DEFAULT_EXPERIMENT_NAME = "Kale-Pipeline-Experiment"
+
 METADATA_GROUP_DESC = """
 Override the arguments of the source Notebook's Kale metadata section
 """
@@ -85,12 +89,9 @@ def main():
     metadata_group.add_argument(
         "--experiment_name",
         type=str,
-        default="Kale-Pipeline-Experiment",
         help="Name of the created experiment",
     )
-    metadata_group.add_argument(
-        "--pipeline_name", type=str, default="kale-pipeline", help="Name of the deployed pipeline"
-    )
+    metadata_group.add_argument("--pipeline_name", type=str, help="Name of the deployed pipeline")
     metadata_group.add_argument(
         "--pipeline_description", type=str, help="Description of the deployed pipeline"
     )
@@ -127,7 +128,16 @@ def main():
         for a in mt_overrides_group._group_actions
         if getattr(args, a.dest, None) is not None
     }
-    processor = NotebookProcessor(args.nb, mt_overrides_group_dict)
+    # Passed as kwargs, not as metadata overrides: NotebookConfig resolves
+    # kwargs *below* the notebook's own metadata, so these act as a last-resort
+    # fallback for a notebook that names neither, while an explicit --pipeline_name
+    # still takes precedence (it lands in mt_overrides_group_dict).
+    processor = NotebookProcessor(
+        args.nb,
+        mt_overrides_group_dict,
+        pipeline_name=DEFAULT_PIPELINE_NAME,
+        experiment_name=DEFAULT_EXPERIMENT_NAME,
+    )
     pipeline = processor.run()
     imports_and_functions = processor.get_imports_and_functions()
     dsl_script_path = Compiler(pipeline, imports_and_functions).compile()

--- a/kale/tests/unit_tests/test_cli.py
+++ b/kale/tests/unit_tests/test_cli.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for how the CLI resolves notebook metadata against its own arguments."""
+
+import nbformat as nbf
+import pytest
+
+from kale.cli import DEFAULT_EXPERIMENT_NAME, DEFAULT_PIPELINE_NAME
+from kale.processors import NotebookProcessor
+
+
+def _write_nb(path, metadata):
+    """Write a single-step notebook whose Kale metadata is `metadata`."""
+    nb = nbf.v4.new_notebook()
+    nb.metadata["kubeflow_notebook"] = {"volumes": [], **metadata}
+    cell = nbf.v4.new_code_cell(source="x = 1")
+    cell.metadata["tags"] = ["step:one"]
+    nb.cells.append(cell)
+    nbf.write(nb, str(path))
+    return path
+
+
+def _cli_config(path, overrides=None):
+    """Build the config the way `kale --nb` does.
+
+    The CLI passes its own defaults as kwargs (resolved *below* the notebook's
+    metadata) and only explicitly-given arguments as metadata overrides
+    (resolved *above* it).
+    """
+    processor = NotebookProcessor(
+        str(path),
+        overrides or {},
+        pipeline_name=DEFAULT_PIPELINE_NAME,
+        experiment_name=DEFAULT_EXPERIMENT_NAME,
+    )
+    return processor.config
+
+
+@pytest.mark.parametrize("field", ["pipeline_name", "experiment_name"])
+def test_notebook_metadata_is_not_clobbered_by_cli_defaults(tmp_path, field):
+    """A name set in the notebook survives a CLI run that does not pass one.
+
+    Regression test: both arguments used to carry an argparse default, so they
+    were always present in the overrides dict and always won over the notebook.
+    Two notebooks compiled in one directory therefore shared a pipeline name and
+    silently overwrote each other's generated modules.
+    """
+    nb = _write_nb(tmp_path / "nb.ipynb", {field: "from-metadata"})
+
+    assert getattr(_cli_config(nb), field) == "from-metadata"
+
+
+@pytest.mark.parametrize(
+    "field,default",
+    [("pipeline_name", DEFAULT_PIPELINE_NAME), ("experiment_name", DEFAULT_EXPERIMENT_NAME)],
+)
+def test_cli_default_applies_when_notebook_names_neither(tmp_path, field, default):
+    """With nothing in the notebook, the CLI default is still the fallback."""
+    nb = _write_nb(tmp_path / "nb.ipynb", {})
+
+    assert getattr(_cli_config(nb), field) == default
+
+
+@pytest.mark.parametrize("field", ["pipeline_name", "experiment_name"])
+def test_explicit_cli_argument_still_wins(tmp_path, field):
+    """An explicitly passed argument keeps precedence over the notebook."""
+    nb = _write_nb(tmp_path / "nb.ipynb", {field: "from-metadata"})
+
+    config = _cli_config(nb, {field: "from-cli"})
+
+    assert getattr(config, field) == "from-cli"
+
+
+def test_two_notebooks_keep_distinct_pipeline_names(tmp_path):
+    """The names two notebooks are compiled under stay distinct.
+
+    This is what keeps their generated sub-pipeline modules from colliding:
+    `_module_name` is keyed on the root pipeline name.
+    """
+    first = _write_nb(tmp_path / "first.ipynb", {"pipeline_name": "first-pipeline"})
+    second = _write_nb(tmp_path / "second.ipynb", {"pipeline_name": "second-pipeline"})
+
+    assert _cli_config(first).pipeline_name != _cli_config(second).pipeline_name


### PR DESCRIPTION
## What this does

Stops `--pipeline_name` and `--experiment_name` from overriding the notebook's own metadata when they weren't actually passed.

Fixes #942.

## Why

Both arguments carried an argparse default, so they were always non-`None` and always survived the filter that builds the metadata-overrides dict:

```python
mt_overrides_group_dict = {
    a.dest: getattr(args, a.dest, None)
    for a in mt_overrides_group._group_actions
    if getattr(args, a.dest, None) is not None      # every other override is None when unset
}
```

Overrides are applied *on top of* the notebook's metadata, so every notebook compiled with `kale --nb` was named `kale-pipeline` no matter what it declared. They're the only two arguments in that group with defaults — the rest correctly resolve to `None`.

That's what produces the collision in #942: `_module_name()` prefixes generated sub-pipeline modules with the root pipeline name, so two composition notebooks in one directory generate identical filenames and the second run silently overwrites the first.

Worth noting the blast radius is a little wider than the issue title suggests — on the CLI path a notebook's `pipeline_name` and `experiment_name` were being ignored outright, so pipelines were also uploaded under the wrong name.

## The fix

Drop both argparse defaults and pass them to `NotebookProcessor` as kwargs instead. `NotebookConfig` resolves them *below* the notebook's metadata:

```python
self.config = NotebookConfig(**{**kwargs, **nb_metadata})
```

so precedence becomes explicit CLI argument → notebook metadata → CLI default, which is what the CLI's own help text describes ("If the same argument is provided both in the Notebook metadata and from CLI, the CLI parameter will take precedence" — for an argument the user actually provided).

## Testing

Reproduced the issue exactly with the shipped examples, then confirmed the fix. Before, both compositions land on the same five files:

```console
$ kale --nb main.ipynb && kale --nb main_mixed.ipynb
$ ls .kale/
kale-pipeline.kale.py                        # overwritten
kale_notebook_kale_pipeline_notebook_a.py    # overwritten
...
```

After, they coexist:

```console
$ ls .kale/
notebook-sequence.kale.py
notebook-sequence-mixed.kale.py
kale_notebook_notebook_sequence_notebook_a.py
kale_notebook_notebook_sequence_mixed_notebook_a.py
...
```

New `kale/tests/unit_tests/test_cli.py` covers the three precedence cases for both fields — metadata is kept when the CLI passes nothing, the default still applies when neither names one, and an explicit argument still wins — plus that two notebooks keep distinct names. Full suite: **328 passed**; `ruff check` and `ruff format --check` clean.

## Note on #945

While reproducing this I looked at #945 (root pipeline parameters not reaching steps inside a referenced notebook) — that's a separate problem in how sub-pipeline inputs are built and isn't affected by this change. Happy to take that one next if nobody else has picked it up.
