### PR TITLE
fix: pass the root notebook's parameters into its references

### DIFF
--- a/kale/compiler.py
+++ b/kale/compiler.py
@@ -86,6 +86,26 @@ def _step_display_name(step_name: str) -> str:
     return f"{step_name.replace('_', '-')}-step"
 
 
+def _parameters_of(pipeline) -> list[dict]:
+    """A pipeline's parameters, as they appear in the generated code.
+
+    ``name`` is the variable a pipeline function declares, ``arg`` the keyword
+    a component receives it under.
+    """
+    parameters = []
+    for param_name, param in getattr(pipeline, "pipeline_parameters", {}).items():
+        if isinstance(param, PipelineParam):
+            parameters.append(
+                {
+                    "name": param_name.lower(),
+                    "arg": _clean_param_name(param_name),
+                    "type": param.param_type or "str",
+                    "default": repr(param.param_value),
+                }
+            )
+    return parameters
+
+
 def _module_name(root_name: str, reference_name: str) -> str:
     """Module a referenced notebook is generated into.
 
@@ -243,9 +263,16 @@ class Compiler:
                 for var in sorted(node.ins)
             ]
             is_subpipeline = isinstance(node, SubPipeline)
-            if not is_subpipeline:
-                # a referenced notebook declares its own parameters; these are
-                # this notebook's, so they go to its own steps
+            if is_subpipeline:
+                # a referenced notebook takes this notebook's parameters under
+                # the names its own pipeline function declares
+                declared = {p["name"] for p in _parameters_of(node.pipeline)}
+                inputs.extend(
+                    {"arg": p["name"], "ref": p["name"]}
+                    for p in parameters
+                    if p["name"] in declared
+                )
+            else:
                 inputs.extend({"arg": p["arg"], "ref": p["name"]} for p in parameters)
             calls.append(
                 {
@@ -336,23 +363,8 @@ class Compiler:
         )
 
     def _parameter_context(self):
-        """The pipeline's parameters, as they appear in the generated code.
-
-        ``name`` is the variable a pipeline function declares, ``arg`` the
-        keyword a component receives it under.
-        """
-        parameters = []
-        for param_name, param in getattr(self.pipeline, "pipeline_parameters", {}).items():
-            if isinstance(param, PipelineParam):
-                parameters.append(
-                    {
-                        "name": param_name.lower(),
-                        "arg": _clean_param_name(param_name),
-                        "type": param.param_type or "str",
-                        "default": repr(param.param_value),
-                    }
-                )
-        return parameters
+        """This pipeline's parameters, as they appear in the generated code."""
+        return _parameters_of(self.pipeline)
 
     def _subpipeline_context(self, node):
         """Template context for one referenced notebook's module.

--- a/kale/processors/nbprocessor.py
+++ b/kale/processors/nbprocessor.py
@@ -296,6 +296,9 @@ class NotebookProcessor:
         )
 
         self.parse_pipeline_parameters(pipeline_parameters_source)
+        # a referenced notebook is processed before this notebook's own
+        # parameters are known, so they are handed down here
+        self.propagate_pipeline_parameters()
         # get a list of variables that need to be logged as pipeline metrics
         pipeline_metrics = astutils.parse_metrics_print_statements(pipeline_metrics_source)
 
@@ -548,6 +551,24 @@ class NotebookProcessor:
                 "Cycle detected in the composition graph. Each cell must appear below "
                 "the cells that produce the variables it uses."
             )
+
+    def propagate_pipeline_parameters(self):
+        """Hand this notebook's pipeline parameters to the notebooks it references.
+
+        A composition exposes one set of parameters, the root's, so a step in a
+        referenced notebook that uses one has to receive it like any other step
+        does. Where both notebooks declare the same name the root's value wins,
+        since that is the one a run is submitted with; the referenced
+        notebook's own value stays its default when it is compiled on its own.
+        """
+        if not self.pipeline.pipeline_parameters:
+            return
+        for node in self.pipeline.steps:
+            if isinstance(node, SubPipeline):
+                node.pipeline.pipeline_parameters = {
+                    **node.pipeline.pipeline_parameters,
+                    **self.pipeline.pipeline_parameters,
+                }
 
     def propagate_subpipeline_boundaries(self):
         """Push a referenced notebook's boundary variables onto its own steps.

--- a/kale/tests/unit_tests/test_composition.py
+++ b/kale/tests/unit_tests/test_composition.py
@@ -353,6 +353,62 @@ def test_referenced_notebook_keeps_its_pipeline_parameters(tmp_path, monkeypatch
     assert "factor=factor" in module
 
 
+def test_root_parameters_reach_a_referenced_notebooks_steps(tmp_path, monkeypatch):
+    """The root's parameters are the composition's parameters, so a step inside
+    a referenced notebook that uses one receives it rather than failing at
+    runtime with a NameError."""
+    _write_nb(
+        tmp_path / "child.ipynb",
+        "child",
+        [(["step:train"], "print(f'child training for {epochs} epochs')")],
+    )
+    root = tmp_path / "root.ipynb"
+    _write_nb(
+        root,
+        "root",
+        [(["pipeline-parameters"], "epochs = 7"), _ref("child", "./child.ipynb")],
+    )
+
+    monkeypatch.chdir(tmp_path)
+    _, dsl_path = _compile(root)
+
+    module = _module(tmp_path, "child")
+    # the component receives it and the parameters block binds it
+    assert "epochs: int = 7" in module
+    assert "epochs = {epochs}" in module
+    # and the nested pipeline declares it, so the root can pass it in
+    assert f"def {_module_name('root', 'child')}_pipeline(epochs: int = 7)" in module
+    assert "epochs=epochs" in open(dsl_path).read()
+
+
+def test_root_parameters_win_over_a_referenced_notebooks_own(tmp_path, monkeypatch):
+    """A composition exposes one value for a name, the root's, since that is the
+    one a run is submitted with. Parameters the root does not declare keep the
+    referenced notebook's own default."""
+    _write_nb(
+        tmp_path / "child.ipynb",
+        "child",
+        [
+            (["pipeline-parameters"], "epochs = 3\nlr = 0.5"),
+            (["step:train"], "print(f'{epochs} {lr}')"),
+        ],
+    )
+    root = tmp_path / "root.ipynb"
+    _write_nb(
+        root,
+        "root",
+        [(["pipeline-parameters"], "epochs = 7"), _ref("child", "./child.ipynb")],
+    )
+
+    monkeypatch.chdir(tmp_path)
+    _compile(root)
+
+    module = _module(tmp_path, "child")
+    assert (
+        f"def {_module_name('root', 'child')}_pipeline(epochs: int = 7, lr: float = 0.5)" in module
+    )
+
+
 def test_step_config_survives_composition(tmp_path, monkeypatch):
     """A step's `limit:`, `label:`, `annotation:` and `cache:` tags have the
     same effect whether the notebook is composed or compiled on its own."""


### PR DESCRIPTION
Fixes #945.

A step inside a referenced notebook could not see the root notebook's pipeline parameters. It compiled clean and raised `NameError` in the pod.

### Cause

`parse_pipeline_parameters` runs after `parse_notebook`, and `parse_notebook` is what spawns the child `NotebookProcessor` for a `notebook:` cell. A referenced notebook was therefore always processed before the root's parameters existed, so it never saw them. The orchestrator then deliberately withheld them at the call site, on the reasoning that a referenced notebook declares its own parameters. That is true, but it also needs the root's.

### Fix

Two changes, mirroring how pipeline-level config already reaches a reference:

- `NotebookProcessor.propagate_pipeline_parameters()` hands the root's parameters down to each referenced notebook's pipeline, immediately after they are parsed.
- `Compiler.generate_composition` passes them at the call site, under the names the nested pipeline function declares.

Everything downstream then follows from the existing code: the nested pipeline exposes them, the component takes them, and the parameters block binds them.

```python
def auto_generated_pipeline(epochs: int = 7):
    kale_notebook_root_child_task = kale_notebook_root_child_pipeline(
        epochs=epochs
    )

def kale_notebook_root_child_pipeline(epochs: int = 7):

def train_step(train_html_report: Output[HTML], epochs: int = 7):
    epochs = {epochs}
```

The IR assertion in the issue inverts: `comp-child` input parameters go from `none` to `['epochs']`.

### On name collisions

The issue does not say what should happen when both notebooks declare the same parameter, so this picks: **the root's value wins**, because that is the value a run is submitted with. A parameter only the referenced notebook declares keeps its own default, and its own value is still used when it is compiled on its own. This matches the rule already agreed for caching and security context, where a composition takes the setting from the notebook the user pressed Compile on. There is a test pinning the behaviour either way.

### Testing

- Two new tests in `test_composition.py`: the issue's exact scenario, and the collision rule.
- 335 backend tests pass.
- The reproducer set from the #867 review is unchanged.
