### PR TITLE
fix: key generated files on the notebook, not a default pipeline name

### DIFF
--- a/kale/cli.py
+++ b/kale/cli.py
@@ -89,7 +89,12 @@ def main():
         help="Name of the created experiment",
     )
     metadata_group.add_argument(
-        "--pipeline_name", type=str, default="kale-pipeline", help="Name of the deployed pipeline"
+        # No default: a default would always be an override, so the notebook's
+        # own `pipeline_name` could never win. Left unset, the name comes from
+        # the notebook's metadata, or from its file name.
+        "--pipeline_name",
+        type=str,
+        help="Name of the deployed pipeline (default: the notebook's own name)",
     )
     metadata_group.add_argument(
         "--pipeline_description", type=str, help="Description of the deployed pipeline"

--- a/kale/compiler.py
+++ b/kale/compiler.py
@@ -89,7 +89,7 @@ def _step_display_name(step_name: str) -> str:
 def _module_name(root_name: str, reference_name: str) -> str:
     """Module a referenced notebook is generated into.
 
-    The root's name is part of it because two notebooks in one directory can
+    The root is part of the name because two notebooks in one directory can
     reference different notebooks under the same name, and their modules are
     written side by side.
     """
@@ -443,8 +443,19 @@ class Compiler:
         return f"{node.name}_task"
 
     def _module_name(self, node):
-        """Module the referenced notebook of ``node`` is generated into."""
-        return _module_name(self.pipeline.config.pipeline_name, node.name)
+        """Module the referenced notebook of ``node`` is generated into.
+
+        Keyed on the root notebook rather than on its pipeline name: file names
+        are necessarily unique within a directory, pipeline names are not.
+        """
+        return _module_name(self._root_name(), node.name)
+
+    def _root_name(self) -> str:
+        """Name identifying the notebook being compiled, for generated files."""
+        notebook = getattr(self.pipeline.config, "notebook_path", "")
+        if notebook:
+            return utils.sanitize_k8s_name(os.path.splitext(os.path.basename(notebook))[0])
+        return self.pipeline.config.pipeline_name
 
     def _boundary_ref(self, node, var):
         """Reference to the task output that satisfies ``var`` for ``node``."""

--- a/kale/processors/nbprocessor.py
+++ b/kale/processors/nbprocessor.py
@@ -154,6 +154,12 @@ class NotebookConfig(PipelineConfig):
 
     def _preprocess(self, kwargs):
         kwargs["steps_defaults"] = self._parse_steps_defaults(kwargs.get("steps_defaults"))
+        if not kwargs.get("pipeline_name") and kwargs.get("notebook_path"):
+            # a notebook that does not name its pipeline is named after itself,
+            # so that two notebooks in one directory do not compile to the same
+            # set of generated files
+            stem = os.path.splitext(os.path.basename(kwargs["notebook_path"]))[0]
+            kwargs["pipeline_name"] = utils.sanitize_k8s_name(stem)
 
     def _parse_steps_defaults(self, steps_defaults):
         """Parse common step configuration defined in the metadata."""

--- a/kale/tests/unit_tests/test_composition.py
+++ b/kale/tests/unit_tests/test_composition.py
@@ -428,6 +428,37 @@ def test_notebook_named_like_a_module_is_safe(tmp_path, monkeypatch):
     assert f"from {_module_name('root', 'json')} import" in open(dsl_path).read()
 
 
+def test_two_compositions_in_one_directory_do_not_collide(tmp_path, monkeypatch):
+    """Generated modules are keyed on the notebook, not on its pipeline name, so
+    two compositions compiled side by side keep their own generated files even
+    when they share a pipeline name and reference the same notebook."""
+    _write_nb(tmp_path / "shared.ipynb", "shared", [(["step:work"], "dataset = [1]")])
+    for root_file in ("first.ipynb", "second.ipynb"):
+        _write_nb(tmp_path / root_file, "same-name", [_ref("shared", "./shared.ipynb")])
+
+    monkeypatch.chdir(tmp_path)
+    for root_file in ("first.ipynb", "second.ipynb"):
+        processor = NotebookProcessor(str(tmp_path / root_file), {"experiment_name": "test"})
+        Compiler(processor.run(), processor.get_imports_and_functions()).compile()
+
+    assert (tmp_path / ".kale" / f"{_module_name('first', 'shared')}.py").exists()
+    assert (tmp_path / ".kale" / f"{_module_name('second', 'shared')}.py").exists()
+
+
+def test_a_notebook_without_a_pipeline_name_is_named_after_itself(tmp_path, monkeypatch):
+    """A notebook that does not name its pipeline compiles under its own file
+    name, so two of them do not land on the same generated files."""
+    notebook = tmp_path / "my_flow.ipynb"
+    _write_nb(notebook, "placeholder", [(["step:only"], "x = 1")])
+    metadata = nbf.read(str(notebook), as_version=4)
+    del metadata.metadata["kubeflow_notebook"]["pipeline_name"]
+    nbf.write(metadata, str(notebook))
+
+    monkeypatch.chdir(tmp_path)
+    processor = NotebookProcessor(str(notebook), {"experiment_name": "test"})
+    assert processor.pipeline.config.pipeline_name == "my-flow"
+
+
 def test_ui_compile_path_composes(tmp_path, monkeypatch):
     """R1 (kubeflow/kale#867 review): the RPC path the Kale panel uses is
     NotebookProcessor plus Compiler, with no CLI involved. It must compose the


### PR DESCRIPTION
Fixes #942.

Two composition notebooks compiled in one directory with `kale --nb` overwrote each other's generated files.

### Cause

Wider than composition. `kale --nb` documents that an explicit CLI argument beats the notebook's metadata:

> If the same argument (e.g. `pipeline_name`) is provided both in the Notebook metadata and from CLI, the CLI parameter will take precedence.

But `--pipeline_name` carried `default="kale-pipeline"`. The overrides dict is built from every argument that is not `None`, so the default was indistinguishable from a value the user typed, and the notebook's own `pipeline_name` could never win. Every notebook compiled on the CLI was called `kale-pipeline`, which is why the issue sees `notebook-sequence` and `notebook-sequence-mixed` ignored.

For a single notebook that meant two files were overwritten. A composition generates one module per referenced notebook, so it meant five.

### Fix

- `--pipeline_name` no longer has a default, restoring the documented precedence.
- A notebook that declares no pipeline name is named after its file, so removing the default cannot turn into a validation failure. One notebook in the repo is in that position (`examples/taxi-cab-classification/read_data.ipynb`).
- `_module_name` keys on the root notebook's file rather than its pipeline name. File names are necessarily unique within a directory; pipeline names are not, so with only the CLI fix two notebooks sharing a name would still collide.

### Result

```console
$ kale --nb main.ipynb
$ ls .kale/
kale_notebook_main_notebook_a.py  notebook-sequence.kale.py
kale_notebook_main_notebook_b.py  notebook-sequence.pipeline.yaml
kale_notebook_main_notebook_c.py

$ kale --nb main_mixed.ipynb
$ ls .kale/
kale_notebook_main_mixed_notebook_a.py  notebook-sequence-mixed.kale.py
kale_notebook_main_mixed_notebook_b.py  notebook-sequence-mixed.pipeline.yaml
kale_notebook_main_mixed_notebook_c.py  (plus main's, untouched)
```

Both notebooks now compile under the names their metadata declares, which the issue called out as being ignored.

### Note on behaviour change

`kale --nb some_notebook.ipynb` no longer writes `kale-pipeline.kale.py`; it writes a file named after the notebook's pipeline. That is the documented behaviour rather than new behaviour, but it is a visible change for anyone who relied on the fixed name. `--pipeline_name` still overrides, unchanged.

### Testing

- Two new tests: two compositions sharing a pipeline name keep separate modules, and a notebook without a pipeline name is named after its file.
- 335 backend tests pass.
- The reproducer set from the #867 review is unchanged.
