### PR TITLE
docs: document multi-notebook composition

### DIFF
--- a/docs/source/concepts/cell-types.md
+++ b/docs/source/concepts/cell-types.md
@@ -17,6 +17,7 @@ editing the notebook JSON directly.
 | `pipeline-metrics`          | -              | `print()` statements in the cell are converted to KFP pipeline metrics. |
 | `step:<name>`               | `step:train_model`              | Declares (or appends to) a pipeline step named `<name>`.               |
 | `prev:<step_name>`          | `prev:load_data`                | Adds a dependency from the current step to `<step_name>`.              |
+| `notebook:<name>`           | `notebook:preprocessing`        | References another notebook, compiled into this pipeline as a nested sub-pipeline. The path lives in the cell's `notebook_path` metadata. |
 | `skip`                      | -                          | Cell is excluded from the pipeline entirely.                           |
 | `annotation:<key>:<value>`  | `annotation:team:ml`            | Adds a Kubernetes annotation to the step's pod.                        |
 | `label:<key>:<value>`       | `label:env:prod`                | Adds a Kubernetes label to the step's pod.                             |
@@ -118,6 +119,37 @@ model.fit(df.drop("y", axis=1), df["y"])
 ```
 
 You can add as many `prev:` tags as you want — one per dependency.
+
+### `notebook:<name>`
+
+References another notebook. The referenced notebook is compiled into the same
+pipeline as a nested sub-pipeline, with each of its own cells still visible as
+a step.
+
+Unlike every other tag, the value here does not carry the information Kale
+needs: the tag names the reference, and the **path lives in the cell's
+`notebook_path` metadata**, resolved relative to the notebook containing the
+cell.
+
+```json
+{
+  "metadata": {
+    "tags": ["notebook:preprocessing"],
+    "notebook_path": "./preprocessing.ipynb"
+  }
+}
+```
+
+The cell itself holds no code. Kale infers the ordering between referenced
+notebooks from the variables they share, exactly as it does between cells, so
+no `prev:` tag is involved.
+
+The `Notebook` cell type is hidden in the JupyterLab panel unless the **Enable
+composable notebooks** setting is on. That setting only controls the editor;
+a notebook that already contains a `notebook:` cell compiles either way.
+
+See [Composing Multiple Notebooks](composition.md) for the full picture,
+including the current limitations.
 
 ### Per-step configuration
 

--- a/docs/source/concepts/composition.md
+++ b/docs/source/concepts/composition.md
@@ -1,0 +1,172 @@
+# Composing Multiple Notebooks
+
+A single notebook is not always the right unit of work. Preprocessing that
+several projects share, a training notebook someone else owns, an evaluation
+step you want to keep separate: these are naturally different notebooks, and
+copying cells between them is how they drift apart.
+
+A `notebook:` cell lets one notebook reference another. The referenced notebook
+is compiled into the same pipeline as a **nested sub-pipeline**, keeping each
+of its cells visible as its own step in the KFP UI.
+
+## A first composition
+
+Take a notebook that prepares data and a notebook that trains on it. Neither
+knows about the other; each is a normal Kale notebook that you can still run
+and compile on its own.
+
+`preprocessing.ipynb`:
+
+```python
+# tag: step:load
+dataset = pd.read_csv("data.csv")
+```
+
+`training.ipynb`:
+
+```python
+# tag: step:train
+model = RandomForestClassifier().fit(dataset, labels)
+```
+
+Now a third notebook composes them. It contains nothing but two reference
+cells:
+
+| cell tags | cell source | cell metadata |
+| --- | --- | --- |
+| `notebook:preprocessing` | *(empty)* | `notebook_path: ./preprocessing.ipynb` |
+| `notebook:training` | *(empty)* | `notebook_path: ./training.ipynb` |
+
+Compiling that notebook produces one pipeline containing both:
+
+```
+  root pipeline
+  ├── preprocessing   (sub-DAG)
+  │     └── load-step
+  └── training        (sub-DAG)
+        └── train-step
+```
+
+We call the notebook holding the references the **root notebook**.
+
+## Where the path lives
+
+The tag names the reference; it does not contain the path. The path lives in
+the cell's metadata, under `notebook_path`, and is resolved relative to the
+notebook that contains the cell.
+
+```json
+{
+  "metadata": {
+    "tags": ["notebook:preprocessing"],
+    "notebook_path": "./preprocessing.ipynb"
+  }
+}
+```
+
+The Kale panel writes both for you: choose the **Notebook** cell type and enter
+a path. A reference cell holds no code of its own, so Kale places a comment in
+it explaining that.
+
+```{note}
+The `Notebook` cell type is hidden by default in the JupyterLab panel. See
+[Enabling the cell type](#enabling-the-cell-type) below, which also explains
+what that setting does and does not control.
+```
+
+## How data crosses a notebook boundary
+
+It crosses the same way it crosses a cell boundary: Kale finds the variables
+one unit produces and another consumes, and marshals them between the two. See
+[Data Passing & Marshalling](data-passing.md) for the mechanism.
+
+The difference is only the level. Inside a notebook, Kale matches variables
+between cells. In a composition, it matches them between whole notebooks, and
+then hands each variable to the specific step inside the referenced notebook
+that actually produces or consumes it.
+
+So in the example above, `training` reads `dataset` and never defines it, while
+`preprocessing` defines it. Kale therefore:
+
+- orders `preprocessing` before `training`, with no `prev:` tag needed
+- marshals `dataset` out of `load-step` and into `train-step` as a KFP artifact
+
+Two referenced notebooks that share no variables get no edge between them, so
+unrelated work still runs in parallel.
+
+## Mixing steps and references
+
+A root notebook can also carry its own `step:` cells alongside its references.
+Its own steps become top-level components in the pipeline, next to the sub-DAGs.
+
+| cell tags | source |
+| --- | --- |
+| `notebook:preprocessing` | *(empty)* |
+| `notebook:training` | *(empty)* |
+| `step:report` | `print(f"accuracy: {accuracy}")` |
+
+A root step runs after everything above it in the notebook and before
+everything below it, so a composition runs the way it reads. Variables cross
+in both directions: a root step can feed a referenced notebook, and a
+referenced notebook can feed a root step.
+
+## What you get out
+
+Each referenced notebook is compiled into its own importable module, written
+next to the root notebook's generated DSL in `.kale/`. The root notebook's DSL
+imports those modules and wires everything together.
+
+Each module is a complete pipeline of its own, so you can read it, and run it
+standalone, independently of the composition that imports it.
+
+## Enabling the cell type
+
+The `Notebook` cell type is gated behind the **Enable composable notebooks**
+setting in the Kale panel's settings (JupyterLab **Settings → Settings Editor →
+Kale**). It is off by default while the feature settles.
+
+```{important}
+The setting controls **only whether the cell type is offered in the
+cell-metadata editor**. It does not gate compilation.
+
+A notebook that already contains a `notebook:` cell compiles as a composition
+whether or not the setting is on, and `kale --nb` never sees the setting at
+all. "Off by default" means the cell type is hidden, not that composition is
+inert.
+```
+
+## Current limitations
+
+Each of these is reported at compile time rather than at pipeline runtime.
+
+**Nested references are not supported.** A referenced notebook cannot itself
+reference a third notebook. Reference every notebook from the root notebook
+instead.
+
+**A reference cell holds no code.** Putting code in a `notebook:` cell raises,
+rather than silently dropping it:
+
+> `` `notebook:training` cell contains code. A cell that references a notebook
+> holds no code of its own. Move the code to its own `step:` cell. ``
+
+Comments are fine, which is why the panel can leave an explanatory one there.
+
+**A notebook cannot reference itself,** directly or through another notebook.
+Reference cycles raise.
+
+**A reference needs a path.** A `notebook:` cell with no `notebook_path` in its
+metadata raises, rather than compiling to nothing.
+
+**Untagged code after a reference needs an owner.** A reference breaks the cell
+merge chain, so an untagged cell after one attaches to the next `step:` cell.
+If there is no following step, it raises rather than being dropped.
+
+**Two references cannot share a name.** Reference names have to be unique
+within a root notebook, since each names a node in the same pipeline.
+
+## Dive deeper
+
+- [Cell Types & Annotations](cell-types.md), the full tag vocabulary
+- [Data Passing & Marshalling](data-passing.md), how variables move between steps
+- [Pipeline Compilation](compilation.md), how a notebook becomes KFP DSL
+- `examples/composition/`, five runnable notebooks demonstrating both shapes

--- a/docs/source/concepts/index.md
+++ b/docs/source/concepts/index.md
@@ -122,4 +122,5 @@ transformation**: notebook → DSL. That means:
 
 - [Cell Types & Annotations](cell-types.md) — the full tag vocabulary
 - [Data Passing & Marshalling](data-passing.md) — how marshalling works and which types are supported
+- [Composing Multiple Notebooks](composition.md) — referencing one notebook from another
 - [Pipeline Compilation](compilation.md) — the exact compilation pipeline, file by file

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -115,6 +115,7 @@ getting-started/quickstart
 concepts/index
 concepts/cell-types
 concepts/data-passing
+concepts/composition
 concepts/compilation
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,10 @@ support an end-to-end data science experience on Kubeflow.
 Some of these have a companion Codelab that can help you getting started:
 
 - Titanic Example [Codelab](https://codelabs.developers.google.com/codelabs/cloud-kubeflow-minikf-kale/#0)
+
+## Multi-notebook composition
+
+[`composition/`](composition/) shows how one notebook references another with a
+`notebook:` cell, so several notebooks compile into a single pipeline. It ships
+two entry points, one composed purely of references and one that adds a step of
+its own. See its [README](composition/README.md).

--- a/examples/composition/README.md
+++ b/examples/composition/README.md
@@ -1,0 +1,88 @@
+# Multi-notebook composition
+
+Five notebooks demonstrating how one notebook references another with a
+`notebook:` cell, so several notebooks compile into a single Kubeflow pipeline.
+
+See [Composing Multiple Notebooks](../../docs/source/concepts/composition.md)
+for the concepts.
+
+## The notebooks
+
+There are two entry points and three notebooks they reference.
+
+| Notebook | Role |
+| --- | --- |
+| `main.ipynb` | **Entry point.** References the three notebooks below and nothing else. |
+| `main_mixed.ipynb` | **Entry point.** The same three references, plus a `step:` cell of its own. |
+| `notebook_a.ipynb` | Produces `names`, `dataset` and `weights`. |
+| `notebook_b.ipynb` | Consumes those, fits a `model` and a `weight_total`. |
+| `notebook_c.ipynb` | Consumes the model, computes a `prediction`, reports a metric. |
+
+`notebook_a`, `notebook_b` and `notebook_c` are ordinary Kale notebooks. None of
+them mentions the others, and each can be compiled and run on its own. What
+links them is that they share variable names, which is all Kale needs to order
+them and pass data between them.
+
+## The two shapes
+
+**`main.ipynb`** holds only references. Every step in the pipeline comes from a
+referenced notebook:
+
+```
+notebook-sequence
+├── notebook-a   ── names-step, generate-step, assemble-step, weights-step
+├── notebook-b   ── show-names-step, fit-step, package-step, aggregate-step
+└── notebook-c   ── predict-step, report-step, combine-step, summary-step
+```
+
+**`main_mixed.ipynb`** is the same three references plus its own `step:final`
+cell, which prints the `prediction` that `notebook_c` produced. Its own step
+becomes a top-level component alongside the three sub-DAGs:
+
+```
+notebook-sequence-mixed
+├── notebook-a   (sub-DAG)
+├── notebook-b   (sub-DAG)
+├── notebook-c   (sub-DAG)
+└── final-step   (a step of the root notebook itself)
+```
+
+That difference is the point of shipping both: the first shows notebooks
+composed end to end, the second shows a root notebook contributing work of its
+own.
+
+## What to look at
+
+Nothing here declares an order. `notebook_b` uses `dataset`, which
+`notebook_a` defines, so `notebook_a` runs first and `dataset` is marshalled
+between them. Open `notebook_a.ipynb` and you will find no mention of
+`notebook_b`, and no `prev:` tag anywhere across the three.
+
+Note also that `weights` is produced by `notebook_a` and consumed by
+`notebook_b`, while `names` is produced by `notebook_a` and consumed by both
+`notebook_b` and `notebook_c`, so the dependency graph is not a straight line.
+
+## Compiling
+
+```console
+$ cd examples/composition
+$ kale --nb main.ipynb
+```
+
+That writes the generated DSL into `.kale/`: one module per referenced
+notebook, plus the pipeline that imports them. Each module is a runnable
+pipeline in its own right.
+
+To compile and submit in one go:
+
+```console
+$ kale --nb main.ipynb --run_pipeline --kfp_host <your-kfp-endpoint>
+```
+
+In JupyterLab, open `main.ipynb`, enable Kale in the panel, and use **Compile
+and Run**. The reference cells show as `notebook: <name>` chips.
+
+> **Note**
+> To author reference cells in the panel rather than just read them, turn on
+> **Enable composable notebooks** in the Kale settings. Compiling these
+> examples does not need it.


### PR DESCRIPTION
Fixes #944.

Multi-notebook composition shipped in #867 with no user-facing documentation. This adds it.

### What is here

**A concepts page**, `docs/source/concepts/composition.md`, added to the toctree next to the other concepts pages. It covers what a `notebook:` cell is, that the path lives in `notebook_path` metadata rather than in the tag, how data crosses a notebook boundary (the same marshalling as between cells, one level up), that each referenced notebook becomes a nested sub-DAG keeping cell-level visibility, mixing a root notebook's own steps with references, and what the generated output looks like.

**The `notebook:` tag added to the vocabulary table** in `cell-types.md`, plus a section for it alongside the other tags. It was missing entirely, so the tag list was incomplete.

**The scope of `enableComposableNotebooks` stated plainly**, in both places a reader might land:

> The setting controls **only whether the cell type is offered in the cell-metadata editor**. It does not gate compilation.
>
> A notebook that already contains a `notebook:` cell compiles as a composition whether or not the setting is on, and `kale --nb` never sees the setting at all. "Off by default" means the cell type is hidden, not that composition is inert.

**A README for `examples/composition/`** explaining the five notebooks, which two are entry points, how `main` and `main_mixed` differ, and how to compile them. It also points out the thing the examples are there to show: none of `notebook_a/b/c` mentions the others and there is no `prev:` tag anywhere, yet they are ordered correctly because they share variable names.

**`composition/` added to `examples/README.md`**, which previously did not list it.

### Limitations section

The page documents each limitation with the error you actually get, since all of them are reported at compile time: nested references, code in a reference cell, reference cycles, a missing `notebook_path`, orphaned untagged code, and duplicate reference names. Each was verified against `main` rather than written from the design docs.

### Notes

The generated file naming is described in general terms ("one module per referenced notebook, written next to the root notebook's DSL") rather than by exact filename, because #942 changes the naming. Nothing here needs updating when that lands.

`docs/proposals/0812-composable-notebooks/` is left alone. It is the KEP, a design document for maintainers, and remains that.

### Testing

- `sphinx-build` completes with no warnings or errors, and the page renders into the concepts section.
- Links to `cell-types.md`, `data-passing.md` and `compilation.md` resolve.
- The examples README uses plain Markdown rather than MyST directives, since GitHub renders it.
