### PR TITLE
fix(frontend): track the active notebook in state so the Enable toggle appears immediately

### DIFF
--- a/labextension/src/widgets/LeftPanel.tsx
+++ b/labextension/src/widgets/LeftPanel.tsx
@@ -32,6 +32,7 @@ import { KaleEmptyState } from './KaleEmptyState';
 import { KFPStatusBadge } from '../components/KFPStatusBadge';
 import kaleLogo from '../../style/icons/kale.svg';
 import { useKfpStatus } from './hooks/useKfpStatus';
+import { useActiveNotebook } from './hooks/useActiveNotebook';
 import { useNotebookMetadata } from './hooks/useNotebookMetadata';
 import { useDeployment } from './hooks/useDeployment';
 import { setLeftPanelCallbacks } from '../commands/kaleToolbar';
@@ -89,6 +90,8 @@ export const KubeflowKaleLeftPanel: React.FC<IProps> = props => {
   );
 
   const kfpStatus = useKfpStatus(kernel, backend);
+
+  const activeNotebook = useActiveNotebook(tracker);
 
   const notebookMeta = useNotebookMetadata({
     tracker,
@@ -220,8 +223,6 @@ export const KubeflowKaleLeftPanel: React.FC<IProps> = props => {
       label="Enable Pipeline Caching"
     />
   );
-
-  const activeNotebook = tracker.currentWidget;
 
   return (
     <ThemeProvider theme={theme}>

--- a/labextension/src/widgets/hooks/useActiveNotebook.ts
+++ b/labextension/src/widgets/hooks/useActiveNotebook.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The Kubeflow Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useState } from 'react';
+import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
+
+/**
+ * Hook that keeps the currently active notebook in React state.
+ *
+ * `tracker.currentWidget` is a plain JupyterLab object, so reading it while
+ * rendering leaves the panel blind to notebook changes: opening a notebook
+ * updates the tracker but schedules no re-render, so the panel keeps showing
+ * whichever branch it last rendered.
+ *
+ * The panel did recover, but only as a side effect: the notebook-loading
+ * sequence sets unrelated state once it finishes, and that re-render happened
+ * to re-read the tracker. That sequence waits on the kernel and then on one
+ * backend RPC after another, so the recovery arrives late on a slow backend
+ * and never at all if a call hangs.
+ *
+ * Subscribing to `currentChanged` here makes the active notebook a value the
+ * panel actually tracks, so it no longer depends on that timing.
+ */
+export function useActiveNotebook(
+  tracker: INotebookTracker,
+): NotebookPanel | null {
+  const [activeNotebook, setActiveNotebook] = useState<NotebookPanel | null>(
+    tracker.currentWidget,
+  );
+
+  useEffect(() => {
+    const onCurrentChanged = (
+      _tracker: INotebookTracker,
+      notebook: NotebookPanel | null,
+    ) => setActiveNotebook(notebook);
+
+    // a notebook may already be open from before this mounted
+    setActiveNotebook(tracker.currentWidget);
+    tracker.currentChanged.connect(onCurrentChanged);
+
+    return () => {
+      tracker.currentChanged.disconnect(onCurrentChanged);
+    };
+  }, [tracker]);
+
+  return activeNotebook;
+}


### PR DESCRIPTION
## What this does

Keeps the active notebook in React state instead of reading `tracker.currentWidget` while rendering, so the Enable toggle appears as soon as a notebook is opened.

Fixes #647.

@ederign — you asked on that issue whether it still reproduces in 2.1. #948 is that check: same bug, reported against current `main`, two months later. I reproduced it on `main` @ `1e28a4f` and it is still there.

## Why

`LeftPanel` picked between the real Enable switch and the "Open a notebook" empty state from `tracker.currentWidget`, read during render:

```ts
const activeNotebook = tracker.currentWidget;   // LeftPanel.tsx:224
```

That is a plain JupyterLab object, so opening a notebook updates it without scheduling a re-render, and the panel keeps showing whichever branch it rendered last.

It did recover, but only incidentally: `loadNotebookPanel` sets unrelated state when it finishes, and that re-render happened to re-read the tracker. That sequence awaits kernel startup and then four backend RPCs in turn, so the recovery arrives late whenever those are slow.

That is also why the KFP status matters, which is the part #948 names. Every RPC is Python executed in the notebook's kernel, and a kernel handles one request at a time. `useKfpStatus` polls `kfp.ping` on that same kernel, and `ping` calls `get_kfp_healthz()` with no timeout — so when KFP is unreachable it holds the kernel while the notebook-load calls queue behind it. That is the ~30s delay in the report, and why "wait about 30 seconds" is the stated workaround.

## The change

A small `useActiveNotebook` hook subscribes to `tracker.currentChanged` and keeps the result in state; `LeftPanel` uses that instead of reading the tracker directly. It seeds from `tracker.currentWidget` on mount so a notebook opened before the panel mounted is still picked up.

Scoped to the branch decision only — `useNotebookLoader` and its await chain are untouched. The missing try/catch around that chain, which you noted at the bottom of #647, is still separate; I saw its "An unhandled error has been thrown" toast while testing and left it alone.

## Testing

Reproduced both cases from #948 with KFP disconnected — opening a notebook after the badge settles, and while it is still checking — and confirmed the toggle appears immediately in both.

Verified as an A/B on the same machine: patch stashed, extension rebuilt, bug reproduced; patch restored, rebuilt, bug gone. Same steps each time, on a reset workspace, opening `examples/composition/main.ipynb`.

|  | `.kale-no-notebook-message` | `.kale-disabled-toggle` |
| --- | --- | --- |
| before | present | present |
| after | absent | absent |

`jlpm build:lib`, `jlpm lint:check`, `jlpm test` and `pytest kale/tests/unit_tests` (329 passed) are all clean.

**Before** — `main.ipynb` is open, but the panel still shows the disabled toggle and the empty state:

![before](https://raw.githubusercontent.com/harshhh817/kale/screenshots/948/before.png)

**After** — same steps, same disconnected KFP:

![after](https://raw.githubusercontent.com/harshhh817/kale/screenshots/948/after.png)

No unit test: the change is a signal subscription with no pure logic to extract, and the extension has no React test renderer, so the pattern used in #868 and #950 does not apply here. Happy to add one if you would rather pull in `@testing-library/react`.
